### PR TITLE
add UseCellIdx Traits in compute_cell_particles

### DIFF
--- a/src/exanb/compute/include/exanb/compute/compute_cell_particles.h
+++ b/src/exanb/compute/include/exanb/compute/compute_cell_particles.h
@@ -54,13 +54,13 @@ namespace exanb
       const unsigned int n = m_cells[cell_a].size();
       ONIKA_CU_BLOCK_SIMD_FOR(unsigned int , p , 0 , n )
       {
-			  if constexpr ( ComputeCellParticlesTraitsUseCellIdx<FuncT>::UseCellIdxt)
+			  if constexpr (  !ComputeCellParticlesTraitsUseCellIdx<FuncT>::UseCellIdx )
 				{
-	        m_func(cell_a, m_cells[cell_a][onika::soatl::FieldId<field_ids>{}][p] ... );
+	        m_func( m_cells[cell_a][onika::soatl::FieldId<field_ids>{}][p] ... );
 				}
 				else
 				{
-	        m_func( m_cells[cell_a][onika::soatl::FieldId<field_ids>{}][p] ... );
+	        m_func(cell_a, m_cells[cell_a][onika::soatl::FieldId<field_ids>{}][p] ... );
 				}
       }
     }


### PR DESCRIPTION
This feature retrieves the cell index when using compute_cell_particles. In particular, it is used to merge other developments using cell partitioning.