### PR TITLE
Output deformed grid vtk

### DIFF
--- a/src/exanb/io/write_deformed_grid_vtk.cpp
+++ b/src/exanb/io/write_deformed_grid_vtk.cpp
@@ -1,0 +1,373 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+#include <memory>
+
+#include <exanb/core/operator.h>
+#include <exanb/core/operator_slot.h>
+#include <exanb/core/operator_factory.h>
+#include <exanb/core/domain.h>
+#include <exanb/core/parallel_grid_algorithm.h>
+#include <onika/memory/allocator.h>
+#include <exanb/grid_cell_particles/grid_cell_values.h>
+#include <exanb/core/grid.h>
+#include <exanb/core/make_grid_variant_operator.h>
+#include <exanb/core/string_utils.h>
+
+#include <mpi.h>
+#include <cstdio>
+#include <experimental/filesystem>
+
+namespace exanb
+{
+
+  template<class GridT>
+  class WriteDeformedGridVTK : public OperatorNode
+  {
+    ADD_SLOT( MPI_Comm       , mpi              , INPUT , REQUIRED );
+    ADD_SLOT( GridT          , grid             , INPUT , REQUIRED );
+    ADD_SLOT( Domain         , domain           , INPUT , REQUIRED );
+    ADD_SLOT( std::string    , filename         , INPUT , "grid" );
+    ADD_SLOT( GridCellValues , grid_cell_values , INPUT , REQUIRED );
+    ADD_SLOT( bool           , use_point_data   , INPUT , true );
+
+  public:
+
+    // -----------------------------------------------
+    // -----------------------------------------------
+    inline void execute ()  override final
+    {
+      namespace fs = std::experimental::filesystem;
+    
+      
+#     ifndef NDEBUG
+      static constexpr size_t scalar_len = 18;
+      static const char* real_format = "% .10e\n";  
+      const std::string test_str = format_string(real_format,123456.0);
+      const size_t scalar_len_test = test_str.length();
+      assert( scalar_len == scalar_len_test );
+      assert( test_str[scalar_len-1] == '\n' );
+#     endif
+
+      const IJK dims = grid->dimension();
+      const ssize_t gl = grid->ghost_layers();      
+      const IJK dom_dims = domain->grid_dimension();
+      //const size_t dom_n_cells = dom_dims.i*dom_dims.j*dom_dims.k;
+      //const Vec3d dom_origin = domain->origin();
+      const double cell_size = domain->cell_size();
+      const IJK dims_no_ghost = dims-2*gl;
+      Mat3d xform = domain->xform();
+      Mat3d lattice = diag_matrix(domain->extent()-domain->origin());
+      Mat3d lot = transpose(xform * lattice);
+      
+      int rank=0, np=1;
+      MPI_Comm_rank(*mpi, &rank);
+      MPI_Comm_size(*mpi, &np);
+
+      ssize_t subdiv = -1;
+      for(const auto& fp:grid_cell_values->fields())
+      {
+        if( subdiv == -1 ) subdiv = fp.second.m_subdiv;
+        else if( subdiv != ssize_t(fp.second.m_subdiv) )
+        {
+          lerr << "inconsistent grid subdivision accross scalar fields" << std::endl;
+          std::abort();
+        }
+      }
+      
+      if( subdiv < 1 )
+      {
+        return;
+      }
+
+      GridBlock local_block = enlarge_block( grid->block() , -gl );
+      std::vector<GridBlock> all_blocks( np );
+      MPI_Allgather( (char*) &local_block, sizeof(GridBlock), MPI_CHAR, (char*) all_blocks.data(), sizeof(GridBlock), MPI_CHAR, *mpi);
+      assert( all_blocks[rank] == local_block);
+      
+      bool point_mode = *use_point_data;
+
+      const IJK whole_ext = (point_mode)? dom_dims*subdiv - 1 : dom_dims*subdiv;
+      
+      ldbg << "extent="<<whole_ext<<", point_mode="<<std::boolalpha<<point_mode <<std::endl;
+
+      std::string basename = *filename;
+      if( basename.rfind('.') != std::string::npos )
+      {
+        basename = basename.substr(0,basename.rfind('.'));
+      }
+      if( rank == 0 ) 
+      {
+        ldbg << "create directory basename"<<std::endl;
+        fs::remove_all(basename);
+        std::error_code ec;
+        fs::create_directory(basename, ec);
+      }
+      MPI_Barrier(*mpi);
+      
+      int Nxmax=whole_ext.i;
+      int Nymax=whole_ext.j;
+      int Nzmax=whole_ext.k;
+
+      if( rank == 0 ) 
+      {
+        std::string pvts_filename = *filename + ".pvts" ;
+        ldbg << "write file "<<pvts_filename<<" ..."<<std::endl;
+        std::ofstream pvts( pvts_filename );
+        pvts << "<VTKFile type=\"PStructuredGrid\" version=\"1.0\" byte_order=\"LittleEndian\" header_type=\"UInt64\">\n";
+        pvts << "  <PStructuredGrid WholeExtent=\"0 "
+             <<whole_ext.i<<" 0 "
+             <<whole_ext.j<<" 0 "
+             <<whole_ext.k<<"\" GhostLevel=\"0\">\n";        
+        bool scalars_set = true;
+        for(const auto& fp:grid_cell_values->fields())
+        {
+          size_t side = fp.second.m_subdiv;
+          size_t n_subcells = side*side*side;
+          size_t n_comps = fp.second.m_components / n_subcells;
+          assert( n_comps*n_subcells == fp.second.m_components );
+          if( scalars_set )
+          {
+            if( point_mode ) pvts << "    <PPointData Scalars=\""<<fp.first<<"\">\n";
+            else             pvts << "    <PCellData Scalars=\""<<fp.first<<"\">\n";
+            scalars_set = false;
+          }
+          pvts << "      <PDataArray type=\"Float64\" Name=\"" << fp.first << "\" NumberOfComponents=\""<<n_comps<<"\"/>\n";
+        }
+        if( point_mode ) pvts <<"    </PPointData>\n";
+        pvts <<"    <PPoints>\n";
+        pvts <<"      <PDataArray type=\"Float64\" Name=\"Points\" NumberOfComponents=\"3\"/>\n";
+        pvts <<"    </PPoints>\n";
+        
+        for(int i=0;i<np;i++)
+        {
+          IJK start, end;
+          end.i = ((all_blocks[i].end.i*subdiv > whole_ext.i) && point_mode) ? all_blocks[i].end.i*subdiv-1 : all_blocks[i].end.i*subdiv;
+          end.j = ((all_blocks[i].end.j*subdiv > whole_ext.j) && point_mode) ? all_blocks[i].end.j*subdiv-1 : all_blocks[i].end.j*subdiv; 
+          end.k = ((all_blocks[i].end.k*subdiv > whole_ext.k) && point_mode) ? all_blocks[i].end.k*subdiv-1 : all_blocks[i].end.k*subdiv; 
+          
+          if(point_mode)
+            {
+              start.i = (all_blocks[i].start.i*subdiv > 0) ? all_blocks[i].start.i*subdiv-1 : 0; 
+              start.j = (all_blocks[i].start.j*subdiv > 0) ? all_blocks[i].start.j*subdiv-1 : 0; 
+              start.k = (all_blocks[i].start.k*subdiv > 0) ? all_blocks[i].start.k*subdiv-1 : 0; 
+            }
+          else
+            {
+              start.i = all_blocks[i].start.i*subdiv; 
+              start.j = all_blocks[i].start.j*subdiv; 
+              start.k = all_blocks[i].start.k*subdiv; 
+            }
+          pvts << "    <Piece Extent=\""
+               << start.i<<" "<<end.i<<" "
+               << start.j<<" "<<end.j<<" "
+               << start.k<<" "<<end.k
+               <<"\" Source=\""<<basename<<"/"<<"piece"<<i<<".vts\"/>\n";
+        }
+        pvts <<"  </PStructuredGrid>\n";
+        pvts <<"</VTKFile>\n";
+      }
+
+
+      // write local processor's piece .vts file
+      std::ostringstream vts_filename_oss;
+      vts_filename_oss <<basename<<"/"<<"piece"<<rank<<".vts";
+      std::string vts_filename = vts_filename_oss.str();
+      ldbg << "write file "<<vts_filename<<" ..."<<std::endl;
+      std::ofstream vts( vts_filename );
+
+      // compute local piece dimensions and data array block size
+      const IJK local_subgrid_dims = dimension( local_block ) * subdiv;
+      uint64_t block_elements = grid_cell_count(local_subgrid_dims);
+      const uint64_t block_size = block_elements * sizeof(double);
+
+      IJK dims_copy = dims_no_ghost;
+      IJK sg_dims = dims_no_ghost*subdiv;
+      
+      IJK start_loc_ext, end_loc_ext;
+      end_loc_ext.i = ((local_block.end.i*subdiv > whole_ext.i) && point_mode) ? local_block.end.i*subdiv-1 : local_block.end.i*subdiv;
+      end_loc_ext.j = ((local_block.end.j*subdiv > whole_ext.j) && point_mode) ? local_block.end.j*subdiv-1 : local_block.end.j*subdiv;
+      end_loc_ext.k = ((local_block.end.k*subdiv > whole_ext.k) && point_mode) ? local_block.end.k*subdiv-1 : local_block.end.k*subdiv;
+
+      if (point_mode)
+        {
+          start_loc_ext.i = (local_block.start.i*subdiv > 0) ? local_block.start.i*subdiv-1 : 0;
+          start_loc_ext.j = (local_block.start.j*subdiv > 0) ? local_block.start.j*subdiv-1 : 0;
+          start_loc_ext.k = (local_block.start.k*subdiv > 0) ? local_block.start.k*subdiv-1 : 0;
+        }
+      else
+        {
+          start_loc_ext.i = local_block.start.i*subdiv;
+          start_loc_ext.j = local_block.start.j*subdiv;
+          start_loc_ext.k = local_block.start.k*subdiv;
+        }
+
+      vts<<"<VTKFile type=\"StructuredGrid\" version=\"1.0\" byte_order=\"LittleEndian\" header_type=\"UInt64\">\n";
+      vts<<"  <StructuredGrid WholeExtent=\""
+         << start_loc_ext.i <<" "<< end_loc_ext.i <<" "
+         << start_loc_ext.j <<" "<< end_loc_ext.j <<" "
+         << start_loc_ext.k <<" "<< end_loc_ext.k <<"\">\n";
+      vts<<"    <Piece Extent=\"";
+      if(point_mode)
+        {
+          vts<<
+            local_block.start.i*subdiv<<" "<< local_block.end.i*subdiv-1 <<" "<<
+            local_block.start.j*subdiv<<" "<< local_block.end.j*subdiv-1 <<" "<<
+            local_block.start.k*subdiv<<" "<< local_block.end.k*subdiv-1 <<"\">\n";
+        }
+      else
+        {
+          vts<<
+            local_block.start.i*subdiv<<" "<< local_block.end.i*subdiv <<" "<<
+            local_block.start.j*subdiv<<" "<< local_block.end.j*subdiv <<" "<<
+            local_block.start.k*subdiv<<" "<< local_block.end.k*subdiv <<"\">\n";
+        }
+      bool scalars_set = true;
+      size_t offset = 0;
+      for(const auto& fp:grid_cell_values->fields())
+      {
+        size_t side = fp.second.m_subdiv;
+        size_t n_subcells = side*side*side;
+        size_t n_comps = fp.second.m_components / n_subcells;
+        assert( n_comps*n_subcells == fp.second.m_components );
+        uint64_t vec_block_size = block_size * n_comps;
+        if( scalars_set )
+        {
+          if( point_mode ) vts << "      <PointData Scalars=\""<<fp.first<<"\">\n";
+          scalars_set = false;
+        }
+        vts << "        <DataArray type=\"Float64\" NumberOfComponents=\""<<n_comps<<"\" Name=\"" << fp.first << "\" format=\"appended\" offset=\""<< offset <<"\"/>\n";
+        offset += sizeof(uint64_t) + vec_block_size;
+      }
+      if( point_mode ) vts<<"      </PointData>\n";
+
+      vts<<"      <Points>\n";
+      vts<<"        <DataArray type=\"Float64\" NumberOfComponents=\"3\" Name=\"Points\" format=\"appended\" offset=\""<<offset<<"\"/>\n";
+      vts<<"      </Points>\n";
+      vts<<"    </Piece>\n";
+      vts<<"  </StructuredGrid>\n";
+      vts<<"  <AppendedData encoding=\"raw\">\n";
+      vts<<"    _";
+
+      assert( dims_no_ghost*subdiv == local_subgrid_dims );
+
+      offset = 0;
+      std::vector<double> buffer;
+      for(const auto& fp:grid_cell_values->fields())
+      {
+        size_t side = fp.second.m_subdiv;
+        size_t n_subcells = side*side*side;
+        size_t n_comps = fp.second.m_components / n_subcells;
+        uint64_t vec_block_size = block_size * n_comps;
+        size_t vec_block_elements = block_elements * n_comps;
+        
+        assert( n_comps*n_subcells == fp.second.m_components );
+        ldbg << "\twrite field "<<fp.first<<std::endl;
+        
+        // write block size
+        vts.write( reinterpret_cast<const char*>(&vec_block_size), sizeof(uint64_t) );
+        
+        buffer.assign( vec_block_elements , 0.0 );
+        auto field_data = grid_cell_values->field_data( fp.second );
+
+        GRID_FOR_BEGIN(dims_copy,_,loc)
+        {
+          const IJK cell_loc = loc + gl; 
+          const size_t cell_i = grid_ijk_to_index( dims , cell_loc );
+          for(int ck=0;ck<subdiv;ck++)
+          for(int cj=0;cj<subdiv;cj++)
+          for(int ci=0;ci<subdiv;ci++)
+          {
+            const IJK sc { ci, cj, ck }; 
+            IJK sg_loc = loc*subdiv+sc; 
+            assert( sg_loc.i>=0 && sg_loc.j>=0 && sg_loc.k>=0 );
+            assert( sg_loc.i < sg_dims.i && sg_loc.j < sg_dims.j && sg_loc.k < sg_dims.k );
+            size_t gcv_index = cell_i * field_data.m_stride +  grid_ijk_to_index( IJK{subdiv,subdiv,subdiv} , sc ) * n_comps;
+            size_t buffer_index = grid_ijk_to_index(sg_dims,sg_loc) * n_comps;
+            for(unsigned int c=0;c<n_comps;c++)
+              {
+                buffer[ buffer_index + c ] = field_data.m_data_ptr[ gcv_index + c ];
+              }
+          }
+        }
+        GRID_FOR_END
+        
+        vts.write( reinterpret_cast<const char*>(buffer.data()), vec_block_size );
+        offset += sizeof(uint64_t) + vec_block_size;
+      }
+
+      // For parallel output of .vts files (structured grid)
+      AABB grid_bounds_corrected;
+      grid_bounds_corrected.bmin = grid->grid_bounds().bmin + grid->ghost_layers() * Vec3d{cell_size, cell_size, cell_size};
+      grid_bounds_corrected.bmax = grid->grid_bounds().bmax - grid->ghost_layers() * Vec3d{cell_size, cell_size, cell_size};
+          
+      // ------------------- Write Points data for Unstructured Grid ------------------- //
+      size_t n_comps = 3;
+      uint64_t vec_block_size = block_size * n_comps;
+      size_t vec_block_elements = block_elements * n_comps;
+      vts.write( reinterpret_cast<const char*>(&vec_block_size), sizeof(uint64_t) );
+      buffer.assign( vec_block_elements , 0.0 );
+      GRID_FOR_BEGIN(dims_copy,_,loc)
+        {
+          const IJK cell_loc = loc + gl;
+          Vec3d pos_cell = grid_bounds_corrected.bmin + Vec3d{cell_size*(cell_loc.i-gl),cell_size*(cell_loc.j-gl),cell_size*(cell_loc.k-gl)};
+          double subcell_size=cell_size/subdiv;
+          
+          for(int ck=0;ck<subdiv;ck++)
+            {
+              for(int cj=0;cj<subdiv;cj++)
+                {
+                  for(int ci=0;ci<subdiv;ci++)
+                    {
+                      const IJK sc { ci, cj, ck }; 
+                      IJK sg_loc = loc*subdiv+sc;
+                      assert( sg_loc.i>=0 && sg_loc.j>=0 && sg_loc.k>=0 );
+                      assert( sg_loc.i < sg_dims.i && sg_loc.j < sg_dims.j && sg_loc.k < sg_dims.k );
+                      size_t buffer_index = grid_ijk_to_index(sg_dims,sg_loc) * n_comps;
+                      Vec3d pos_real = xform * ( pos_cell + subcell_size * Vec3d{ci,cj,ck} );
+                      buffer[ buffer_index + 0 ] = pos_real.x;
+                      buffer[ buffer_index + 1 ] = pos_real.y;
+                      buffer[ buffer_index + 2 ] = pos_real.z;
+                    }
+                }
+            }
+        }
+      GRID_FOR_END      
+        // ------------------------------------------------------------------------------- //
+      vts.write( reinterpret_cast<const char*>(buffer.data()), vec_block_size );
+      vts<<"\n  </AppendedData>\n</VTKFile>\n";      
+    }
+
+    // -----------------------------------------------
+    // -----------------------------------------------
+    inline std::string documentation() const override final
+    {
+      return R"EOF(
+Write a structured grid's scalar fields to a .pvts vtk file (along with its .vts sub files)
+)EOF";
+    }
+  
+  };
+
+  // === register factories ===
+  CONSTRUCTOR_FUNCTION
+  {
+   OperatorNodeFactory::instance()->register_factory("write_deformed_grid_vtk", make_grid_variant_operator< WriteDeformedGridVTK > );
+  }
+
+}


### PR DESCRIPTION
WARNING : To be pulled when parallel-execution-streaming is pulled!! 
output-deformed-grid-vtk is based on parallel-execution-streaming and up-to-date with it.

When performing dynamic deformation of the simulation domain using xform functions, one might want to use the fields projection onto a regular grid for saving disk storage or analyzing results on 3D grids instead of particle data. This new operator allows for generating grid vtk with the UnstructuredGrid format. The nodes coordinates are in the real space and evolve with time, instead of begin in "cell" coordinate as with the basic write_grid_vtk operator that outputs vtk using the ImageData format.  

Works in parallel and for any subdiv values (nodes coordinates are calculated accordingly).

Basic usage is the following :

dump_data:
  - grid_flavor
  - resize_grid_cell_values
  - atom_cell_projection:
      fields: [ "mv2" , "mass" ]
      grid_subdiv: 2
      splat_size: 4.5 ang
  - timestep_file: "structured_grid_%09d"
  - write_deformed_grid_vtk