### PR TITLE
use non empty cells with the reduce_cell_operator operator

### DIFF
--- a/src/exanb/compute/include/exanb/compute/reduce_cell_particles.h
+++ b/src/exanb/compute/include/exanb/compute/reduce_cell_particles.h
@@ -58,19 +58,32 @@ namespace exanb
     const ssize_t m_ghost_layers = 0;
     const FuncT m_func;
     ResultT* m_reduced_val = nullptr;
+    const size_t* m_cell_idxs = nullptr; // List of non empty cells
     FieldAccTupleT m_cpfields;
 
     ONIKA_HOST_DEVICE_FUNC inline void operator () ( uint64_t i ) const
     {
       ResultT local_val = ResultT();
 
-      size_t cell_a = i;
-      IJK cell_a_loc = grid_index_to_ijk( m_grid_dims - 2 * m_ghost_layers , i ); ;
-      cell_a_loc = cell_a_loc + m_ghost_layers;
-      if( m_ghost_layers != 0 )
+      size_t cell_a = -1; 
+      IJK cell_a_loc;
+
+      if( m_cell_idxs != nullptr ) 
       {
-        cell_a = grid_ijk_to_index( m_grid_dims , cell_a_loc );
+        cell_a = m_cell_idxs[i];
       }
+      else 
+      {
+        cell_a_loc = grid_index_to_ijk( m_grid_dims - 2 * m_ghost_layers , i );
+        cell_a_loc = cell_a_loc + m_ghost_layers;
+        if( m_ghost_layers != 0 )
+        {
+          cell_a = grid_ijk_to_index( m_grid_dims , cell_a_loc );
+        }
+      }
+
+      assert( cell_a != size_t(-1) && "cell_a is not correctly uninitialized");
+
       const unsigned int n = m_cells[cell_a].size();
 
       ONIKA_CU_BLOCK_SIMD_FOR(unsigned int , p , 0 , n )
@@ -133,7 +146,9 @@ namespace exanb
     ResultT& reduced_val , // initial value is used as a start value for reduction
     const onika::FlatTuple<FieldAccT...>& cp_fields ,
     onika::parallel::ParallelExecutionContext * exec_ctx ,
-    onika::parallel::ParallelExecutionCallback user_cb = {} )
+    onika::parallel::ParallelExecutionCallback user_cb ,
+    const size_t* cell_idxs = nullptr ,
+    size_t n_cells = 0 )
   {
     using onika::parallel::block_parallel_for;
     using ParForOpts = onika::parallel::BlockParallelForOptions;
@@ -143,10 +158,14 @@ namespace exanb
     using CellsAccessorT = std::conditional_t< has_external_or_optional_fields , std::remove_cv_t<std::remove_reference_t<decltype(grid.cells_accessor())> > , CellsPointerT >;
     using PForFuncT = ReduceCellParticlesFunctor<CellsAccessorT,FuncT,ResultT,FieldTupleT, std::make_index_sequence<sizeof...(FieldAccT)> >;
 
+    if( n_cells == 0 ) cell_idxs = nullptr;
+
     const IJK dims = grid.dimension();
     const int gl = enable_ghosts ? 0 : grid.ghost_layers();
     const IJK block_dims = dims - (2*gl);
-    const size_t N = block_dims.i * block_dims.j * block_dims.k;
+    const size_t N = n_cells > 0 ? n_cells : block_dims.i * block_dims.j * block_dims.k;
+
+    assert(cells != nullptr || n_cells <= 0 ); 
 
     ResultT* target_reduced_value_ptr = &reduced_val;
     if constexpr ( ReduceCellParticlesTraits<FuncT>::CudaCompatible )
@@ -162,7 +181,7 @@ namespace exanb
     if constexpr ( has_external_or_optional_fields ) cells = grid.cells_accessor();
     else cells = grid.cells();
 
-    PForFuncT pfor_func = { cells , dims , gl , func , target_reduced_value_ptr , cp_fields };
+    PForFuncT pfor_func = { cells , dims , gl , func , target_reduced_value_ptr , cell_idxs , cp_fields };
     return block_parallel_for( N, pfor_func , exec_ctx , ParForOpts{ .user_cb = user_cb , .return_data = &reduced_val, .return_data_size = sizeof(ResultT) } );
   }
 
@@ -176,12 +195,13 @@ namespace exanb
     ResultT& reduced_val , // initial value is used as a start value for reduction
     FieldSet<field_ids...> ,
     onika::parallel::ParallelExecutionContext * exec_ctx , 
-    onika::parallel::ParallelExecutionCallback user_cb = {} )
+    onika::parallel::ParallelExecutionCallback user_cb = {},
+    const size_t* cell_idxs = nullptr ,
+    size_t n_cells = 0 )
   {
     using FieldTupleT = onika::FlatTuple< onika::soatl::FieldId<field_ids> ... >;
     FieldTupleT cp_fields = { onika::soatl::FieldId<field_ids>{} ... };
-    return reduce_cell_particles(grid,enable_ghosts,func,reduced_val,cp_fields,exec_ctx, user_cb );
+    return reduce_cell_particles(grid,enable_ghosts,func,reduced_val,cp_fields,exec_ctx, user_cb, cell_idxs, n_cells );
   }
-
 }
 


### PR DESCRIPTION
This PR is an optimization of the reduce_cell_particles operator for simulation with a lot of empty cells (90% or more). Speedup=7.2 for my example, two reductions -> vertex_displ and simulation_state.

Old results : 

```
  loop ............................................  1.304e+04            0.000   0.000         1  99.68% / 100.00%
    scheme ........................................  6.127e+03            0.000   0.000     10000  46.84% / 46.98%
      combined_compute_prolog .....................  1.688e+02            0.000   0.000     10000   1.29% /  1.29%
      mpi_barrier
      check_and_update_particles ..................  5.083e+03            0.000   0.000     10000  38.86% / 38.98%
        vertex_displ_over .........................  4.854e+03            0.000   0.000     10000  37.10% / 37.22%

...

    end_iteration .................................  6.904e+03            0.000   0.000     10000  52.78% / 52.95%
      nth_timestep
      nth_timestep
      nth_timestep
      nth_timestep
      nth_timestep
      trigger_thermo_state ........................  3.145e+00            0.000   0.000     10000   0.02% /  0.02%
        boolean_or
        boolean_or
      nth_timestep
      thermo_state_if_triggered ...................  6.877e+03            0.000   0.000      1001  52.57% / 52.74%
        simulation_state ..........................  6.876e+03            0.000   0.000      1001  52.57% / 52.73%
```

Now 

```

  loop ............................................  1.820e+03            0.000   0.000         1  98.15% / 100.00%
    scheme ........................................  1.503e+03            0.000   0.000     10000  81.06% / 82.59%
      combined_compute_prolog .....................  1.490e+02            0.000   0.000     10000   8.04% /  8.19%
      mpi_barrier .................................  5.390e-01            0.000   0.000     10000   0.03% /  0.03%
      check_and_update_particles ..................  5.895e+02            0.000   0.000     10000  31.80% / 32.40%
        vertex_displ_over .........................  3.992e+02            0.000   0.000     10000  21.53% / 21.94%
...

    end_iteration .................................  2.342e+02            0.000   0.000     10000  11.33% / 11.54%
      nth_timestep ................................  8.717e-01            0.000   0.000     10000   0.04% /  0.04%
      nth_timestep ................................  8.892e-01            0.000   0.000     10000   0.04% /  0.04%
      nth_timestep ................................  8.875e-01            0.000   0.000     10000   0.04% /  0.04%
      nth_timestep ................................  6.498e-01            0.000   0.000     10000   0.03% /  0.03%
      nth_timestep ................................  6.577e-01            0.000   0.000     10000   0.03% /  0.03%
      trigger_thermo_state ........................  2.498e+00            0.000   0.000     10000   0.12% /  0.12%
        boolean_or ................................  4.440e-01            0.000   0.000     10000   0.02% /  0.02%
        boolean_or ................................  4.345e-01            0.000   0.000     10000   0.02% /  0.02%
      nth_timestep ................................  7.233e-01            0.000   0.000     10000   0.03% /  0.04%
      thermo_state_if_triggered ...................  2.109e+02            0.000   0.000      1001  10.20% / 10.40%
        simulation_state ..........................  2.107e+02            0.000   0.000      1001  10.19% / 10.38%
```