### PR TITLE
makes update_ghost_config initializaion operator so applications can be future proof

### DIFF
--- a/src/mpi/include/exanb/mpi/update_ghost_config.h
+++ b/src/mpi/include/exanb/mpi/update_ghost_config.h
@@ -1,0 +1,66 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+#pragma once
+
+#include <onika/cuda/cuda_context.h>
+#include <onika/yaml/yaml_utils.h>
+#include <onika/log.h>
+
+namespace exanb
+{
+  struct UpdateGhostConfig
+  {
+    onika::cuda::CudaDevice * alloc_on_device = nullptr;
+    long mpi_tag = 0;
+    bool gpu_buffer_pack = false;
+    bool async_buffer_pack = false;
+    bool staging_buffer = false;
+    bool serialize_pack_send = true;
+    bool wait_all = false;
+    bool device_side_buffer = false;
+  };
+}
+
+namespace YAML
+{
+
+  template<> struct convert< exanb::UpdateGhostConfig >
+  {
+    static inline bool decode(const Node& node, exanb::UpdateGhostConfig & config)
+    {
+      if( ! node.IsMap() )
+      {
+        exanb::fatal_error() << "UpdateGhostConfig must be a map" << std::endl;
+        return false;
+      }
+      config = exanb::UpdateGhostConfig{};
+      if(node["mpi_tag"])             config.mpi_tag             = node["mpi_tag"].as<int>();
+      if(node["gpu_buffer_pack"])     config.gpu_buffer_pack     = node["gpu_buffer_pack"].as<bool>();
+      if(node["async_buffer_pack"])   config.async_buffer_pack   = node["async_buffer_pack"].as<bool>();
+      if(node["staging_buffer"])      config.staging_buffer      = node["staging_buffer"].as<bool>();
+      if(node["serialize_pack_send"]) config.serialize_pack_send = node["serialize_pack_send"].as<bool>();
+      if(node["wait_all"])            config.wait_all            = node["wait_all"].as<bool>();
+      if(node["device_side_buffer"])  config.device_side_buffer  = node["device_side_buffer"].as<bool>();
+      return true;
+    }
+  };
+
+}
+

--- a/src/mpi/update_ghost_config.cpp
+++ b/src/mpi/update_ghost_config.cpp
@@ -1,0 +1,109 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+#include <onika/scg/operator.h>
+#include <onika/scg/operator_slot.h>
+#include <onika/scg/operator_factory.h>
+
+#include <exanb/mpi/update_ghost_config.h>
+
+namespace exanb
+{
+  class UpdateGhostConfigOperator : public OperatorNode
+  {
+
+    // -----------------------------------------------
+    // Operator slots
+    // -----------------------------------------------
+    ADD_SLOT( UpdateGhostConfig , update_ghost_config , INPUT_OUTPUT , UpdateGhostConfig{} );
+    ADD_SLOT( bool , verbose , INPUT , false );
+    
+  public:
+    inline void execute() override final
+    {
+      if( global_cuda_ctx() == nullptr || ! global_cuda_ctx()->has_devices() || ! global_cuda_ctx()->global_gpu_enable() )
+      {
+        update_ghost_config->gpu_buffer_pack = false;
+      }
+      
+      if( ! update_ghost_config->gpu_buffer_pack )
+      {
+        update_ghost_config->device_side_buffer = false;
+      }
+      
+      if( update_ghost_config->device_side_buffer && update_ghost_config->alloc_on_device == nullptr )
+      {
+        update_ghost_config->alloc_on_device = & ( global_cuda_ctx()->m_devices[0] );
+      }
+      
+      if( *verbose )
+      {
+        lout << "============ Update Ghhost Configuration =========" << std::endl
+             << "mpi_tag             = "<<update_ghost_config->mpi_tag<< std::endl
+             << "gpu_buffer_pack     = "<<std::boolalpha << update_ghost_config->gpu_buffer_pack<< std::endl
+             << "async_buffer_pack   = "<<std::boolalpha << update_ghost_config->async_buffer_pack<< std::endl
+             << "staging_buffer      = "<<std::boolalpha << update_ghost_config->staging_buffer<< std::endl
+             << "serialize_pack_send = "<<std::boolalpha << update_ghost_config->serialize_pack_send<< std::endl
+             << "wait_all            = "<<std::boolalpha << update_ghost_config->wait_all<< std::endl
+             << "device_side_buffer  = "<<std::boolalpha << update_ghost_config->device_side_buffer<< std::endl
+             << "alloc_on_device     = "<< (void*) update_ghost_config->alloc_on_device << std::endl
+             << "=================================================="<< std::endl << std::endl;
+      }
+    }
+
+    inline void yaml_initialize(const YAML::Node& node) override final
+    {
+      YAML::Node tmp;
+      if( ! node["update_ghost_config"] )
+      {
+        tmp["update_ghost_config"] = node;
+      }
+      else { tmp = node; }
+      this->OperatorNode::yaml_initialize(tmp);
+    }
+
+    inline std::string documentation() const override final
+    {
+      return R"EOF(
+
+Initializes and outputs a configuration strucure for subsequent update_ghosts and update_from_ghosts nodes.
+
+Usage example:
+
+update_ghosts_config:
+  mpi_tag: 0
+  gpu_buffer_pack: true
+  async_buffer_pack: true
+  staging_buffer: false
+  serialize_pack_send: true
+  wait_all: false
+  device_side_buffer: true
+  
+)EOF";
+    }    
+  };
+
+  // === register factory ===
+  ONIKA_AUTORUN_INIT(update_ghost_config)
+  {
+    OperatorNodeFactory::instance()->register_factory("update_ghost_config",make_compatible_operator<UpdateGhostConfigOperator>);
+  }
+
+}
+


### PR DESCRIPTION
the goal is to be able to switch to new update ghost implementation by simply switching the exaNBody branch without changing client application. this needs this extra component "update_ghost_config" wich basically fills an "update_ghost_config" slot of type UpdateGhostConfig. this is harmless since it does nothing but setting up this structure which will not be used