### PR TITLE
111 write xyz quaternion

### DIFF
--- a/src/io/include/exanb/io/write_xyz.h
+++ b/src/io/include/exanb/io/write_xyz.h
@@ -170,7 +170,7 @@ namespace exanb
         else if constexpr ( std::is_same_v<field_type,Quaternion> )
         {
           const T v = ( conv != 1.0 ) ? static_cast<T>( in_v * conv ) : in_v;
-          return onika::format_string_buffer( buf, bufsize, format_for_value(v) , v.w, v.x , v.y , v.z );
+          return onika::format_string_buffer( buf, bufsize, format_for_value(v) , v.w , v.x , v.y , v.z );
         }
         else if constexpr ( is_array_of_integral_v<field_type,4> )
         {


### PR DESCRIPTION
J'ai juste rajouté le "real4" dans l'écrivain xyz car c'était pas formatté correctement dans les sorties .xyz

Nécessaire pour les quaternions notamment (@rprat-pro ça peut t'être utile)

