### PR TITLE
140 ghost update grid cell values

### DIFF
--- a/src/mpi/include/exanb/mpi/grid_update_ghosts.h
+++ b/src/mpi/include/exanb/mpi/grid_update_ghosts.h
@@ -21,26 +21,24 @@ under the License.
 
 #include <mpi.h>
 
-#include <onika/mpi/data_types.h>
-#include <onika/math/basic_types_stream.h>
-#include <onika/soatl/field_tuple.h>
-#include <onika/parallel/block_parallel_for.h>
 #include <onika/cuda/stl_adaptors.h>
+#include <onika/math/basic_types_stream.h>
+#include <onika/mpi/data_types.h>
+#include <onika/parallel/block_parallel_for.h>
 #include <onika/soatl/field_id_tuple_utils.h>
+#include <onika/soatl/field_tuple.h>
 
-#include <exanb/core/grid.h>
-#include <exanb/core/particle_id_codec.h>
 #include <exanb/core/check_particles_inside_cell.h>
-#include <exanb/core/grid_particle_field_accessor.h>
 #include <exanb/core/domain.h>
+#include <exanb/core/grid.h>
 #include <exanb/core/grid_particle_field_accessor.h>
+#include <exanb/core/particle_id_codec.h>
 
 #include <exanb/grid_cell_particles/grid_cell_values.h>
 
-#include <exanb/mpi/update_ghost_config.h>
 #include <exanb/mpi/ghosts_comm_scheme.h>
+#include <exanb/mpi/update_ghost_config.h>
 #include <exanb/mpi/update_ghosts_comm_manager.h>
-
 
 namespace exanb
 {
@@ -62,23 +60,9 @@ namespace exanb
   serialize_pack_sends requires to wait until all send packets are filled before starting to send the first one
   gpu_packing allows pack/unpack operations to execute on the GPU
   */
-  template<class LDBGT, class GridT, class UpdateGhostsScratchT, class PECFuncT, class PEQFuncT , class FieldAccTupleT, bool CreateParticles=false>
-  static inline void grid_update_ghosts(
-    LDBGT& ldbg,
-    MPI_Comm comm,
-    GhostCommunicationScheme& comm_scheme,
-    GridT* gridp,
-    const Domain& domain,
-    GridCellValues* grid_cell_values,
-    UpdateGhostsScratchT& ghost_comm_buffers,
-    const PECFuncT& parallel_execution_context,
-    const PEQFuncT& parallel_execution_queue,
-    const FieldAccTupleT& update_fields,
-    const UpdateGhostConfig& config,
-    std::integral_constant<bool,CreateParticles> create_cell_particles = {}
-    )
+  template <class LDBGT, class GridT, class UpdateGhostsScratchT, class PECFuncT, class PEQFuncT, class FieldAccTupleT, bool CreateParticles = false> static inline void grid_update_ghosts(LDBGT &ldbg, MPI_Comm comm, GhostCommunicationScheme &comm_scheme, GridT *gridp, const Domain &domain, GridCellValues *grid_cell_values, UpdateGhostsScratchT &ghost_comm_buffers, const PECFuncT &parallel_execution_context, const PEQFuncT &parallel_execution_queue, const FieldAccTupleT &update_fields, const UpdateGhostConfig &config, std::integral_constant<bool, CreateParticles> create_cell_particles = {})
   {
-    auto [alloc_on_device,comm_tag,gpu_buffer_pack,async_buffer_pack,staging_buffer,serialize_pack_send,wait_all] = config;
+    auto [alloc_on_device, comm_tag, gpu_buffer_pack, async_buffer_pack, staging_buffer, serialize_pack_send, wait_all] = config;
 
     const bool has_opt_field = field_tuple_contains_optional_field(update_fields);
     const bool has_field_span = field_tuple_contains_field_span(update_fields);
@@ -86,57 +70,54 @@ namespace exanb
     using CellParticlesAllocator = typename GridT::CellParticlesAllocator;
     //    using CellParticlesUpdateData = typename UpdateGhostsUtils::GhostCellParticlesUpdateData;
 
-    static_assert( sizeof(uint8_t) == 1 , "uint8_t is not a byte");
+    static_assert(sizeof(uint8_t) == 1, "uint8_t is not a byte");
 
-    using CellsAccessorT = std::remove_cv_t< std::remove_reference_t< decltype( gridp->cells_accessor() ) > >;
+    using CellsAccessorT = std::remove_cv_t<std::remove_reference_t<decltype(gridp->cells_accessor())>>;
     using onika::parallel::block_parallel_for;
 
-    if( create_cell_particles && gridp==nullptr )
+    if (create_cell_particles && gridp == nullptr)
     {
-      fatal_error() << "request for ghost particle creation while null grid passed in"<< std::endl;
+      fatal_error() << "request for ghost particle creation while null grid passed in" << std::endl;
     }
 
-    static const CellParticlesAllocator default_cell_allocator( onika::memory::DefaultAllocator{ onika::memory::CUDA_FALLBACK_ALLOC_POLICY } );
-    const size_t sizeof_ParticleTuple = onika::soatl::field_id_tuple_size_bytes( update_fields );
+    static const CellParticlesAllocator default_cell_allocator(onika::memory::DefaultAllocator{onika::memory::CUDA_FALLBACK_ALLOC_POLICY});
+    const size_t sizeof_ParticleTuple = onika::soatl::field_id_tuple_size_bytes(update_fields);
 
     int nprocs = 1;
     int rank = 0;
-    MPI_Comm_size(comm,&nprocs);
-    MPI_Comm_rank(comm,&rank);
+    MPI_Comm_size(comm, &nprocs);
+    MPI_Comm_rank(comm, &rank);
 
-    const size_t ghost_layers = (gridp!=nullptr) ? gridp->ghost_layers() : ( (grid_cell_values!=nullptr) ? grid_cell_values->ghost_layers() : 0 );
-    const IJK grid_dims = (gridp!=nullptr) ? gridp->dimension() : ( (grid_cell_values!=nullptr) ? grid_cell_values->grid_dims() : IJK{0,0,0} );
-    const IJK grid_domain_offset = (gridp!=nullptr) ? gridp->offset() : ( (grid_cell_values!=nullptr) ? grid_cell_values->grid_offset() : IJK{0,0,0} );
+    const size_t ghost_layers = (gridp != nullptr) ? gridp->ghost_layers() : ((grid_cell_values != nullptr) ? grid_cell_values->ghost_layers() : 0);
+    const IJK grid_dims = (gridp != nullptr) ? gridp->dimension() : ((grid_cell_values != nullptr) ? grid_cell_values->grid_dims() : IJK{0, 0, 0});
+    const IJK grid_domain_offset = (gridp != nullptr) ? gridp->offset() : ((grid_cell_values != nullptr) ? grid_cell_values->grid_offset() : IJK{0, 0, 0});
     double cell_size = domain.cell_size();
-    const Vec3d grid_start_position = domain.origin() + ( grid_domain_offset * cell_size );
-    const size_t n_cells = (gridp!=nullptr) ? gridp->number_of_cells() : ( (grid_cell_values!=nullptr) ? grid_cell_values->number_of_cells() : 0 );
+    const Vec3d grid_start_position = domain.origin() + (grid_domain_offset * cell_size);
+    const size_t n_cells = (gridp != nullptr) ? gridp->number_of_cells() : ((grid_cell_values != nullptr) ? grid_cell_values->number_of_cells() : 0);
 
-    if( gridp!=nullptr )
+    if (gridp != nullptr)
     {
-      assert( n_cells == gridp->number_of_cells() );
-      assert( ghost_layers == gridp->ghost_layers() );
-      assert( grid_dims == gridp->dimension() );
-      assert( grid_domain_offset == gridp->offset() );
-      assert( grid_start_position == gridp->cell_position({0,0,0}) );
+      assert(n_cells == gridp->number_of_cells());
+      assert(ghost_layers == gridp->ghost_layers());
+      assert(grid_dims == gridp->dimension());
+      assert(grid_domain_offset == gridp->offset());
+      assert(grid_start_position == gridp->cell_position({0, 0, 0}));
     }
-    if( grid_cell_values!=nullptr )
+    if (grid_cell_values != nullptr)
     {
-      assert( n_cells == grid_cell_values->number_of_cells() );
-      assert( ghost_layers == grid_cell_values->ghost_layers() );
-      assert( grid_dims == grid_cell_values->grid_dims() );
-      assert( grid_domain_offset == grid_cell_values->grid_offset() );
+      assert(n_cells == grid_cell_values->number_of_cells());
+      assert(ghost_layers == grid_cell_values->ghost_layers());
+      assert(grid_dims == grid_cell_values->grid_dims());
+      assert(grid_domain_offset == grid_cell_values->grid_offset());
     }
-    ldbg<<"grid_update_ghosts : n_cells="<<n_cells<<", ghost_layers="<<ghost_layers<<", grid_dims="<<grid_dims
-        <<", grid_domain_offset="<<grid_domain_offset<<", grid_start_position="<<grid_start_position
-        <<", cell_size="<<cell_size<< ", sizeof_ParticleTuple="<<sizeof_ParticleTuple
-        <<", gpu_buffer_pack="<<gpu_buffer_pack<<", has_opt_field="<<has_opt_field<<", has_field_span="<<has_field_span <<std::endl;
+    ldbg << "grid_update_ghosts : n_cells=" << n_cells << ", ghost_layers=" << ghost_layers << ", grid_dims=" << grid_dims << ", grid_domain_offset=" << grid_domain_offset << ", grid_start_position=" << grid_start_position << ", cell_size=" << cell_size << ", sizeof_ParticleTuple=" << sizeof_ParticleTuple << ", gpu_buffer_pack=" << gpu_buffer_pack << ", has_opt_field=" << has_opt_field << ", has_field_span=" << has_field_span << std::endl;
 
-    auto * const cells = (gridp!=nullptr) ? gridp->cells() : nullptr;
-    const onika::soatl::PackedFieldArraysAllocator & cell_allocator = (gridp!=nullptr) ? gridp->cell_allocator() : default_cell_allocator;
-    const GhostBoundaryModifier ghost_boundary = { domain.origin() , domain.extent() };
+    auto *const cells = (gridp != nullptr) ? gridp->cells() : nullptr;
+    const onika::soatl::PackedFieldArraysAllocator &cell_allocator = (gridp != nullptr) ? gridp->cell_allocator() : default_cell_allocator;
+    const GhostBoundaryModifier ghost_boundary = {domain.origin(), domain.extent()};
 
     // per cell scalar values, if any
-    GridCellValueType* cell_scalars = nullptr;
+    GridCellValueType *cell_scalars = nullptr;
     unsigned int cell_scalar_components = 0;
     if( grid_cell_values != nullptr  )
     {
@@ -147,28 +128,29 @@ namespace exanb
         cell_scalars = grid_cell_values->data().data();
       }
     }
-    if( cell_scalars )
+    if (cell_scalars)
     {
-      ldbg << "update ghost cell values with "<< cell_scalar_components << " components"<<std::endl;
+      ldbg << "update ghost cell values with " << cell_scalar_components << " components" << std::endl;
     }
     else
     {
       cell_scalar_components = 0;
     }
 
-    CellsAccessorT cells_accessor = { nullptr , nullptr };
-    if( gridp != nullptr ) cells_accessor = gridp->cells_accessor();
+    CellsAccessorT cells_accessor = {nullptr, nullptr};
+    if (gridp != nullptr)
+      cells_accessor = gridp->cells_accessor();
 
     // ***************** send/receive buffers resize ******************
-    ghost_comm_buffers.update_from_comm_scheme( rank, comm_scheme, ghost_comm_buffers, cells_accessor, cell_scalars, cell_scalar_components, update_fields, ghost_boundary, alloc_on_device, staging_buffer, async_buffer_pack );
+    ghost_comm_buffers.update_from_comm_scheme(rank, comm_scheme, ghost_comm_buffers, cells_accessor, cell_scalars, cell_scalar_components, update_fields, ghost_boundary, alloc_on_device, staging_buffer, async_buffer_pack);
     ghost_comm_buffers.reactivate_requests();
 
     // ***************** resize cells if needed ******************
-    ghost_comm_buffers.resize_received_cells( cells, cell_allocator, create_cell_particles );
+    ghost_comm_buffers.resize_received_cells(cells, cell_allocator, create_cell_particles);
 
     // ***************** send bufer packing start ******************
-    //uint8_t* send_buf_ptr = ghost_comm_buffers.mpi_send_buffer();
-    int active_send_packs = ghost_comm_buffers.start_pack_functors( parallel_execution_queue, parallel_execution_context, rank, gpu_buffer_pack );
+    // uint8_t* send_buf_ptr = ghost_comm_buffers.mpi_send_buffer();
+    int active_send_packs = ghost_comm_buffers.start_pack_functors(parallel_execution_queue, parallel_execution_context, rank, gpu_buffer_pack);
 
     // number of flying messages
     int active_sends = 0;
@@ -176,44 +158,47 @@ namespace exanb
     int request_count = 0;
 
     // ***************** async receive start ******************
-    request_count = active_recvs = ghost_comm_buffers.start_mpi_receives(comm,comm_tag,rank);
+    request_count = active_recvs = ghost_comm_buffers.start_mpi_receives(comm, comm_tag, rank);
 
     // ***************** initiate buffer sends ******************
-    if( serialize_pack_send ) parallel_execution_queue().wait();
-    while( active_sends < active_send_packs )
+    if (serialize_pack_send)
+      parallel_execution_queue().wait();
+    while (active_sends < active_send_packs)
     {
       active_sends += ghost_comm_buffers.start_ready_mpi_sends(parallel_execution_queue, comm, comm_tag, rank, serialize_pack_send);
     }
     request_count += active_sends;
 
-    assert( ghost_comm_buffers.number_of_requests() == request_count );
-    assert( ghost_comm_buffers.number_of_requests() == ( active_sends + active_recvs ) );
-    ldbg << "UpdateGhosts : total active requests = "<<ghost_comm_buffers.number_of_requests()<<std::endl;
+    assert(ghost_comm_buffers.number_of_requests() == request_count);
+    assert(ghost_comm_buffers.number_of_requests() == (active_sends + active_recvs));
+    ldbg << "UpdateGhosts : total active requests = " << ghost_comm_buffers.number_of_requests() << std::endl;
 
     // manage loopback communication : decode packet directly from sendbuffer without actually receiving it
-    size_t ghost_cells_self=0;
-    if( ghost_comm_buffers.send_info(rank).buffer_size > 0 || ghost_comm_buffers.recv_info(rank).buffer_size > 0 )
+    size_t ghost_cells_self = 0;
+    if (ghost_comm_buffers.send_info(rank).buffer_size > 0 || ghost_comm_buffers.recv_info(rank).buffer_size > 0)
     {
-      assert( ghost_comm_buffers.send_info(rank).buffer_size == ghost_comm_buffers.recv_info(rank).buffer_size );
-      ldbg << "UpdateGhosts: loopback buffer size="<<ghost_comm_buffers.send_info(rank).buffer_size<<std::endl;
-      if( ! serialize_pack_send ) { parallel_execution_queue().wait( ghost_comm_buffers.pack_functor_lane[rank] ); }
-      ghost_cells_self = ghost_comm_buffers.process_received_buffer(parallel_execution_queue, parallel_execution_context,rank,gpu_buffer_pack );
+      assert(ghost_comm_buffers.send_info(rank).buffer_size == ghost_comm_buffers.recv_info(rank).buffer_size);
+      ldbg << "UpdateGhosts: loopback buffer size=" << ghost_comm_buffers.send_info(rank).buffer_size << std::endl;
+      if (!serialize_pack_send)
+      {
+        parallel_execution_queue().wait(ghost_comm_buffers.pack_functor_lane[rank]);
+      }
+      ghost_cells_self = ghost_comm_buffers.process_received_buffer(parallel_execution_queue, parallel_execution_context, rank, gpu_buffer_pack);
     }
 
-    const size_t ghost_cells_recv = ghost_comm_buffers.wait_mpi_messages(parallel_execution_queue, parallel_execution_context,rank,wait_all,gpu_buffer_pack);
+    const size_t ghost_cells_recv = ghost_comm_buffers.wait_mpi_messages(parallel_execution_queue, parallel_execution_context, rank, wait_all, gpu_buffer_pack);
 
-    for(int p=0;p<nprocs;p++)
+    for (int p = 0; p < nprocs; p++)
     {
-      parallel_execution_queue().wait( ghost_comm_buffers.unpack_functor_lane[p] );
+      parallel_execution_queue().wait(ghost_comm_buffers.unpack_functor_lane[p]);
     }
 
-    if( create_cell_particles )
+    if (create_cell_particles)
     {
       gridp->rebuild_particle_offsets();
     }
 
-    ldbg << "--- end update_ghosts : received "<<ghost_cells_recv<<" cells and loopbacked "<<ghost_cells_self<<" cells"<< std::endl;
+    ldbg << "--- end update_ghosts : received " << ghost_cells_recv << " cells and loopbacked " << ghost_cells_self << " cells" << std::endl;
   }
 
-}
-
+} // namespace exanb

--- a/src/mpi/include/exanb/mpi/update_from_ghosts.h
+++ b/src/mpi/include/exanb/mpi/update_from_ghosts.h
@@ -47,11 +47,11 @@ under the License.
 namespace exanb
 {
 
-  template< class GridT, class FieldSetT, class UpdateFuncT = UpdateValueAdd >
+  template< class GridT, class FieldSetT, class UpdateFuncT = UpdateValueAdd , bool UpdateGridCellValues = true>
   class UpdateFromGhostsTmpl;
 
-  template< class GridT, class UpdateFuncT, class... fids >
-  class UpdateFromGhostsTmpl< GridT , FieldSet<fids...> , UpdateFuncT > : public OperatorNode
+  template< class GridT, class UpdateFuncT, bool UpdateGridCellValues, class... fids >
+  class UpdateFromGhostsTmpl< GridT , FieldSet<fids...> , UpdateFuncT , UpdateGridCellValues > : public OperatorNode
   {  
     using generic_real_accessor_t =  std::remove_cv_t< std::remove_reference_t< decltype( std::declval<GridT>().field_accessor( field::generic_real{""} ) ) > >;
     using generic_vec3_accessor_t =  std::remove_cv_t< std::remove_reference_t< decltype( std::declval<GridT>().field_accessor( field::generic_vec3{""} ) ) > >;
@@ -127,8 +127,17 @@ namespace exanb
         ldbg<< ", Particle size ="<<onika::soatl::field_id_tuple_size_bytes( update_fields )<< std::endl;
 
         std::integral_constant<bool,false> dont_create_cell_particles = {};
+
+        if (UpdateGridCellValues) 
+        {
         grid_update_ghosts( ldbg, *mpi, *ghost_comm_scheme, grid.get_pointer(), *domain, grid_cell_values.get_pointer(),
                           *ghost_scratch, pecfunc,peqfunc, update_fields,*update_ghost_config, dont_create_cell_particles );
+        }
+        else
+        {
+        grid_update_ghosts( ldbg, *mpi, *ghost_comm_scheme, grid.get_pointer(), *domain, nullptr,
+                          *ghost_scratch, pecfunc,peqfunc, update_fields,*update_ghost_config, dont_create_cell_particles );
+        }
       };
 
       auto update_fields = onika::make_flat_tuple( grid->field_accessor( onika::soatl::FieldId<fids>{} ) ...
@@ -140,8 +149,8 @@ namespace exanb
 
   };
 
-  template< class GridT , class FieldSetT , class UpdateFuncT = UpdateValueAdd >
-  using UpdateFromGhosts = UpdateFromGhostsTmpl< GridT , FieldSetT , UpdateFuncT >;
+  template< class GridT , class FieldSetT , class UpdateFuncT = UpdateValueAdd , bool UpdateGridCellValues = true>
+  using UpdateFromGhosts = UpdateFromGhostsTmpl< GridT , FieldSetT , UpdateFuncT , UpdateGridCellValues >;
 
 }
 

--- a/src/mpi/include/exanb/mpi/update_ghosts.h
+++ b/src/mpi/include/exanb/mpi/update_ghosts.h
@@ -126,7 +126,7 @@ namespace exanb
         print_field_tuple( ldbg , update_fields );
         ldbg<< ", Particle size ="<<onika::soatl::field_id_tuple_size_bytes( update_fields )<< std::endl;
 
-        GridCellValues * gride_cell_values_ptr = UpdateGridCellValues ? grid_cell_values.get_pointer() : nullptr;
+        GridCellValues * grid_cell_values_ptr = UpdateGridCellValues ? grid_cell_values.get_pointer() : nullptr;
         grid_update_ghosts( ldbg, *mpi, *ghost_comm_scheme, grid.get_pointer(), *domain, grid_cell_values_ptr,
                             * ghost_scratch, pecfunc,peqfunc, update_fields,
                             upd_config, std::integral_constant<bool,CreateParticles>{} );

--- a/src/mpi/include/exanb/mpi/update_ghosts.h
+++ b/src/mpi/include/exanb/mpi/update_ghosts.h
@@ -46,11 +46,11 @@ under the License.
 
 namespace exanb
 {
-  template< class GridT, class FieldSetT , bool CreateParticles >
+  template< class GridT, class FieldSetT , bool CreateParticles , bool UpdateGridCellValues >
   class UpdateGhostsNodeTmpl;
 
-  template< class GridT, bool CreateParticles, class... fids>
-  class UpdateGhostsNodeTmpl< GridT , FieldSet<fids...> , CreateParticles > : public OperatorNode
+  template< class GridT, bool CreateParticles, bool UpdateGridCellValues, class... fids>
+  class UpdateGhostsNodeTmpl< GridT , FieldSet<fids...> , CreateParticles, UpdateGridCellValues > : public OperatorNode
   {
     using generic_real_accessor_t =  std::remove_cv_t< std::remove_reference_t< decltype( std::declval<GridT>().field_accessor( field::generic_real{""} ) ) > >;
     using generic_vec3_accessor_t =  std::remove_cv_t< std::remove_reference_t< decltype( std::declval<GridT>().field_accessor( field::generic_vec3{""} ) ) > >;
@@ -125,10 +125,21 @@ namespace exanb
         ldbg << pathname() << " : ";
         print_field_tuple( ldbg , update_fields );
         ldbg<< ", Particle size ="<<onika::soatl::field_id_tuple_size_bytes( update_fields )<< std::endl;
-
+        
+        if (UpdateGridCellValues) 
+        {
         grid_update_ghosts( ldbg, *mpi, *ghost_comm_scheme, grid.get_pointer(), *domain, grid_cell_values.get_pointer(),
                             * ghost_scratch, pecfunc,peqfunc, update_fields,
                             upd_config, std::integral_constant<bool,CreateParticles>{} );
+        } 
+        else
+        {
+        grid_update_ghosts( ldbg, *mpi, *ghost_comm_scheme, grid.get_pointer(), *domain, nullptr,
+                            * ghost_scratch, pecfunc,peqfunc, update_fields,
+                            upd_config, std::integral_constant<bool,CreateParticles>{} );
+        }
+
+
       };
 
       // build-up list of field accessors to use for ghost update
@@ -185,7 +196,7 @@ dump_data:
     }    
   };
 
-  template< class GridT, class FieldSetT, bool CreateParticles>
-  using UpdateGhostsNode = UpdateGhostsNodeTmpl< GridT , FieldSetT , CreateParticles >;
+  template< class GridT, class FieldSetT, bool CreateParticles, bool UpdateGridCellValues>
+  using UpdateGhostsNode = UpdateGhostsNodeTmpl< GridT , FieldSetT , CreateParticles , UpdateGridCellValues>;
 }
 

--- a/src/mpi/include/exanb/mpi/update_ghosts.h
+++ b/src/mpi/include/exanb/mpi/update_ghosts.h
@@ -125,21 +125,11 @@ namespace exanb
         ldbg << pathname() << " : ";
         print_field_tuple( ldbg , update_fields );
         ldbg<< ", Particle size ="<<onika::soatl::field_id_tuple_size_bytes( update_fields )<< std::endl;
-        
-        if (UpdateGridCellValues) 
-        {
-        grid_update_ghosts( ldbg, *mpi, *ghost_comm_scheme, grid.get_pointer(), *domain, grid_cell_values.get_pointer(),
+
+        GridCellValues * gride_cell_values_ptr = UpdateGridCellValues ? grid_cell_values.get_pointer() : nullptr;
+        grid_update_ghosts( ldbg, *mpi, *ghost_comm_scheme, grid.get_pointer(), *domain, grid_cell_values_ptr,
                             * ghost_scratch, pecfunc,peqfunc, update_fields,
                             upd_config, std::integral_constant<bool,CreateParticles>{} );
-        } 
-        else
-        {
-        grid_update_ghosts( ldbg, *mpi, *ghost_comm_scheme, grid.get_pointer(), *domain, nullptr,
-                            * ghost_scratch, pecfunc,peqfunc, update_fields,
-                            upd_config, std::integral_constant<bool,CreateParticles>{} );
-        }
-
-
       };
 
       // build-up list of field accessors to use for ghost update

--- a/src/mpi/update_force_from_ghost.cu
+++ b/src/mpi/update_force_from_ghost.cu
@@ -41,13 +41,17 @@ namespace exanb
   using namespace UpdateGhostsUtils;
 
   // === register factory ===
-  template<typename GridT> using UpdateForceFromGhosts = UpdateFromGhosts< GridT , FieldSet<field::_fx,field::_fy,field::_fz> , UpdateValueAdd >;
-  template<typename GridT> using UpdateOptFromGhosts = UpdateFromGhosts< GridT , FieldSet<> , UpdateValueAdd >;
+  template<typename GridT> using UpdateForceFromGhosts = UpdateFromGhosts< GridT , FieldSet<field::_fx,field::_fy,field::_fz> , UpdateValueAdd , true >;
+  template<typename GridT> using UpdateOptFromGhosts = UpdateFromGhosts< GridT , FieldSet<> , UpdateValueAdd , true >;
+  template<typename GridT> using UpdateForceFromGhostsNoGCV = UpdateFromGhosts< GridT , FieldSet<field::_fx,field::_fy,field::_fz> , UpdateValueAdd , false >;
+  template<typename GridT> using UpdateOptFromGhostsNoGCV = UpdateFromGhosts< GridT , FieldSet<> , UpdateValueAdd , false >;
 
   ONIKA_AUTORUN_INIT(update_force_from_ghost)
   {
     OperatorNodeFactory::instance()->register_factory( "update_force_from_ghost", make_grid_variant_operator<UpdateForceFromGhosts> );
     OperatorNodeFactory::instance()->register_factory( "update_opt_from_ghost", make_grid_variant_operator<UpdateForceFromGhosts> );
+    OperatorNodeFactory::instance()->register_factory( "update_force_from_ghost_no_gcv", make_grid_variant_operator<UpdateForceFromGhostsNoGCV> );
+    OperatorNodeFactory::instance()->register_factory( "update_opt_from_ghost_no_gcv", make_grid_variant_operator<UpdateForceFromGhostsNoGCV> );
   }
 
 }

--- a/src/mpi/update_ghosts.cu
+++ b/src/mpi/update_ghosts.cu
@@ -42,17 +42,25 @@ namespace exanb
   using namespace UpdateGhostsUtils;
 
   // === register factory ===
-  template<typename GridT> using UpdateGhostsAllFields = UpdateGhostsNode< GridT , AddDefaultFields< typename GridT::Fields > , true >;
-  template<typename GridT> using UpdateGhostsR = UpdateGhostsNode< GridT , FieldSet<field::_rx, field::_ry, field::_rz> , false >;
-  template<typename GridT> using UpdateGhostsAllFieldsNoFV = UpdateGhostsNode< GridT , AddDefaultFields< RemoveFields< typename GridT::Fields , FieldSet<field::_fx,field::_fy,field::_fz,field::_vx, field::_vy, field::_vz > > > , true >;
-  template<typename GridT> using UpdateGhostsOptOnly = UpdateGhostsNode< GridT , FieldSet<> , false >;
-
+  template<typename GridT> using UpdateGhostsAllFields = UpdateGhostsNode< GridT , AddDefaultFields< typename GridT::Fields > , true , true >;
+  template<typename GridT> using UpdateGhostsR = UpdateGhostsNode< GridT , FieldSet<field::_rx, field::_ry, field::_rz> , false , true >;
+  template<typename GridT> using UpdateGhostsAllFieldsNoFV = UpdateGhostsNode< GridT , AddDefaultFields< RemoveFields< typename GridT::Fields , FieldSet<field::_fx,field::_fy,field::_fz,field::_vx, field::_vy, field::_vz > > > , true , true >;
+  template<typename GridT> using UpdateGhostsOptOnly = UpdateGhostsNode< GridT , FieldSet<> , false , true >;
+  template<typename GridT> using UpdateGhostsAllFieldsNoGCV = UpdateGhostsNode< GridT , AddDefaultFields< typename GridT::Fields > , true , false >;
+  template<typename GridT> using UpdateGhostsRNoGCV = UpdateGhostsNode< GridT , FieldSet<field::_rx, field::_ry, field::_rz> , false , false >;
+  template<typename GridT> using UpdateGhostsAllFieldsNoFVNoGCV = UpdateGhostsNode< GridT , AddDefaultFields< RemoveFields< typename GridT::Fields , FieldSet<field::_fx,field::_fy,field::_fz,field::_vx, field::_vy, field::_vz > > > , true , false >;
+  template<typename GridT> using UpdateGhostsOptOnlyNoGCV = UpdateGhostsNode< GridT , FieldSet<> , false , false >;
+  
   ONIKA_AUTORUN_INIT(update_ghosts)
   {
-    OperatorNodeFactory::instance()->register_factory( "ghost_update_all",       make_grid_variant_operator<UpdateGhostsAllFields> );
-    OperatorNodeFactory::instance()->register_factory( "ghost_update_all_no_fv", make_grid_variant_operator<UpdateGhostsAllFieldsNoFV> );
-    OperatorNodeFactory::instance()->register_factory( "ghost_update_r",         make_grid_variant_operator<UpdateGhostsR> );
-    OperatorNodeFactory::instance()->register_factory( "ghost_update_opt",       make_grid_variant_operator<UpdateGhostsOptOnly> );
+    OperatorNodeFactory::instance()->register_factory( "ghost_update_all",              make_grid_variant_operator<UpdateGhostsAllFields> );
+    OperatorNodeFactory::instance()->register_factory( "ghost_update_all_no_fv",        make_grid_variant_operator<UpdateGhostsAllFieldsNoFV> );
+    OperatorNodeFactory::instance()->register_factory( "ghost_update_r",                make_grid_variant_operator<UpdateGhostsR> );
+    OperatorNodeFactory::instance()->register_factory( "ghost_update_opt",              make_grid_variant_operator<UpdateGhostsOptOnly> );
+    OperatorNodeFactory::instance()->register_factory( "ghost_update_all_no_gcv",       make_grid_variant_operator<UpdateGhostsAllFieldsNoGCV> );
+    OperatorNodeFactory::instance()->register_factory( "ghost_update_all_no_fv_no_gcv", make_grid_variant_operator<UpdateGhostsAllFieldsNoFVNoGCV> );
+    OperatorNodeFactory::instance()->register_factory( "ghost_update_r_no_gcv",         make_grid_variant_operator<UpdateGhostsRNoGCV> );
+    OperatorNodeFactory::instance()->register_factory( "ghost_update_opt_no_gcv",       make_grid_variant_operator<UpdateGhostsOptOnlyNoGCV> );    
   }
 
 }


### PR DESCRIPTION
Added variants of all ghost_update functions (update ghosts and update from ghosts) with "_no_gcv" extension such that the user can ask for no update of grid_cell_values.

Update ghost operators that update grid_cell_values:

```bash
update_force_from_ghost
update_opt_from_ghost
ghost_update_all
ghost_update_all_no_fv
ghost_update_r
ghost_update_opt
```

Update ghost operators that **DO  NOT** update grid_cell_values:

```bash
update_force_from_ghost_no_gcv
update_opt_from_ghost_no_gcv
ghost_update_all_no_gcv
ghost_update_all_no_fv_no_gcv
ghost_update_r_no_gcv
ghost_update_opt_no_gcv
```