### PR TITLE
153 set particle type operator

### DIFF
--- a/contribs/microStamp/samples/io/set_particle_type.msp
+++ b/contribs/microStamp/samples/io/set_particle_type.msp
@@ -1,91 +1,63 @@
-configuration:
-  physics:
-    units:
-      length: angstrom
-      mass: Dalton
-      time: picosecond
-      charge: elementary_charge
-      temperature: kelvin
-      amount: particle
-      luminosity: candela
-      angle: radian
-      energy: joule
-  logging:
-    debug: false
-    parallel: true
-  onika:
-    gpu_block_dims: [ 1 , 1 , 1 ]
-
 global:
   dt: 1.0e-5 ps
-  rcut_max: 8.0 ang
-  rcut_inc: 1.0 ang # additional distance so that we d'ont have to rebuild neighbor list each time step
+  rcut_max: 4.0 ang
+  rcut_inc: 1.0 ang
   simulation_log_frequency: 1
   simulation_end_iteration: 1
 
 compute_force: nop
 
 input_data:
-  - particle_types:
-      particle_type_map: { A: 0 , B: 1 , C: 2 }
-  - particle_type_add_properties:
-      A: { radius: 1.5 ang , charge: 1 e- }
-      B: { radius: 2.0 ang , test: 3 ang  }
-      C: { radius: 2.5 ang , bibi: 2 eV  }      
-  - particle_regions:
-      - PLANE1:
-          quadric:
-            shape: { plane: [ 1 , 0 , 0 , 0 ] }
-            transform:
-              - zrot: pi/4
-              - translate: [ 20 ang , 150 ang , 0 ]
-      - PLANE2:
-          quadric:
-            shape: { plane: [ 1 , 0 , 0 , 0 ] }
-            transform:
-              - zrot: -pi/4
-              - translate: [ 20 ang , 150 ang , 0 ]
-      - BOX:
-          bounds: [ [ 250 ang , 0 ang , 0 ang ] , [ 300 ang , 300 ang , 300 ang ] ]
-      - SPHERE:
-          quadric:
-            shape: sphere
-            transform:
-              - scale: [ 20 ang , 20 ang , 20 ang ] 
-              - translate: [ 150 ang , 150 ang , 150 ang ]
   - domain:
-      cell_size: 30.0 ang
-      grid_dims: [ 10 , 10 , 10 ]
-      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 300.0 ang , 300.0 ang , 300.0 ang ] ]
+      cell_size: 10.0 ang
+      grid_dims: [ 20 , 20 , 2 ]
+      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 200.0 ang , 200.0 ang , 20.0 ang ] ]
       periodic: [ true , true , true ]
       expandable: false
       xform: [ [ 1 , 0 , 0 ] , [ 0 , 1 , 0 ] , [ 0 , 0 , 1 ] ]
   - init_rcb_grid
+  - particle_types:
+      particle_type_map: { A: 0 , B: 1 , C: 2 , D: 3}
+  - particle_type_add_properties:
+      A: { radius: 1.0 ang , charge: 1 e- }
+      B: { radius: 1.2 ang , test: 3 ang  }
+      C: { radius: 0.7 ang , bibi: 2 eV  }      
+      D: { radius: 1.5 ang , bibi: 2 eV  }
+  - particle_regions:
+      - BOX:
+          bounds: [ [ 25 ang , 25 ang , -100 ang ] , [ 50 ang , 120 ang , 100 ang ] ]
+      - BOX2:
+          bounds: [ [ 75 ang , 5 ang , -100 ang ] , [ 180 ang , 35 ang , 100 ang ] ]
+      - CYL:
+          quadric:
+            shape: cylz
+            transform:
+              - scale: [ 20 ang , 50 ang , 20 ang ]
+              - zrot: pi/4
+              - translate: [ 120 ang , 130 ang , 0 ang ]
   - lattice:
       structure: SC
       types: [ A ]
-      size: [ 3. ang , 3. ang , 3. ang ]
+      size: [ 2.5 ang , 2.5 ang , 2.5 ang ]
   - gaussian_noise_r:
-      sigma: 0.1 ang
+      sigma: 0.5 ang
       sigma_cut: 0.4 ang
-      region: PLANE1 or PLANE2 or BOX or SPHERE
   - set_particle_type:
       type: B
-      fraction: 0.1
       seed: 432
+      region: BOX
   - set_particle_type:
-      region: SPHERE
       type: C
-      fraction: 0.5
+      region: CYL
+  - set_particle_type:
+      type: D
+      region: BOX2
+      fraction: 0.3
       
 final_dump:
   - write_xyz:
       filename: "test_set_particle_type.xyz"
       fields: [ id , type , radius , charge , bibi , test ]
-
-# pretty logo banner
-logo_banner:
-  - message: "           _               ____  _\n _ __ ___ (_) ___ _ __ ___/ ___|| |_ __ _ _ __ ___  _ __\n| '_ ` _ \\| |/ __| '__/ _ \\___ \\| __/ _` | '_ ` _ \\| '_ \\\n| | | | | | | (__| | | (_) |__) | || (_| | | | | | | |_) |\n|_| |_| |_|_|\\___|_|  \\___/____/ \\__\\__,_|_| |_| |_| .__/\n                                                   |_|\n"
 
 simulation: default_simulation
 

--- a/contribs/microStamp/samples/io/set_particle_type.msp
+++ b/contribs/microStamp/samples/io/set_particle_type.msp
@@ -28,6 +28,10 @@ compute_force: nop
 input_data:
   - particle_types:
       particle_type_map: { A: 0 , B: 1 , C: 2 }
+  - particle_type_add_properties:
+      A: { radius: 1.5 ang , charge: 1 e- }
+      B: { radius: 2.0 ang , test: 3 ang  }
+      C: { radius: 2.5 ang , bibi: 2 eV  }      
   - particle_regions:
       - PLANE1:
           quadric:
@@ -77,7 +81,7 @@ input_data:
 final_dump:
   - write_xyz:
       filename: "test_set_particle_type.xyz"
-      fields: [ id , type ]
+      fields: [ id , type , radius , charge , bibi , test ]
 
 # pretty logo banner
 logo_banner:

--- a/contribs/microStamp/samples/io/set_particle_type.msp
+++ b/contribs/microStamp/samples/io/set_particle_type.msp
@@ -1,0 +1,87 @@
+configuration:
+  physics:
+    units:
+      length: angstrom
+      mass: Dalton
+      time: picosecond
+      charge: elementary_charge
+      temperature: kelvin
+      amount: particle
+      luminosity: candela
+      angle: radian
+      energy: joule
+  logging:
+    debug: false
+    parallel: true
+  onika:
+    gpu_block_dims: [ 1 , 1 , 1 ]
+
+global:
+  dt: 1.0e-5 ps
+  rcut_max: 8.0 ang
+  rcut_inc: 1.0 ang # additional distance so that we d'ont have to rebuild neighbor list each time step
+  simulation_log_frequency: 1
+  simulation_end_iteration: 1
+
+compute_force: nop
+
+input_data:
+  - particle_types:
+      particle_type_map: { A: 0 , B: 1 , C: 2 }
+  - particle_regions:
+      - PLANE1:
+          quadric:
+            shape: { plane: [ 1 , 0 , 0 , 0 ] }
+            transform:
+              - zrot: pi/4
+              - translate: [ 20 ang , 150 ang , 0 ]
+      - PLANE2:
+          quadric:
+            shape: { plane: [ 1 , 0 , 0 , 0 ] }
+            transform:
+              - zrot: -pi/4
+              - translate: [ 20 ang , 150 ang , 0 ]
+      - BOX:
+          bounds: [ [ 250 ang , 0 ang , 0 ang ] , [ 300 ang , 300 ang , 300 ang ] ]
+      - SPHERE:
+          quadric:
+            shape: sphere
+            transform:
+              - scale: [ 20 ang , 20 ang , 20 ang ] 
+              - translate: [ 150 ang , 150 ang , 150 ang ]
+  - domain:
+      cell_size: 30.0 ang
+      grid_dims: [ 10 , 10 , 10 ]
+      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 300.0 ang , 300.0 ang , 300.0 ang ] ]
+      periodic: [ true , true , true ]
+      expandable: false
+      xform: [ [ 1 , 0 , 0 ] , [ 0 , 1 , 0 ] , [ 0 , 0 , 1 ] ]
+  - init_rcb_grid
+  - lattice:
+      structure: SC
+      types: [ A ]
+      size: [ 3. ang , 3. ang , 3. ang ]
+  - gaussian_noise_r:
+      sigma: 0.1 ang
+      sigma_cut: 0.4 ang
+      region: PLANE1 or PLANE2 or BOX or SPHERE
+  - set_particle_type:
+      type: B
+      fraction: 0.1
+      seed: 432
+  - set_particle_type:
+      region: SPHERE
+      type: C
+      fraction: 0.5
+      
+final_dump:
+  - write_xyz:
+      filename: "test_set_particle_type.xyz"
+      fields: [ id , type ]
+
+# pretty logo banner
+logo_banner:
+  - message: "           _               ____  _\n _ __ ___ (_) ___ _ __ ___/ ___|| |_ __ _ _ __ ___  _ __\n| '_ ` _ \\| |/ __| '__/ _ \\___ \\| __/ _` | '_ ` _ \\| '_ \\\n| | | | | | | (__| | | (_) |__) | || (_| | | | | | | |_) |\n|_| |_| |_|_|\\___|_|  \\___/____/ \\__\\__,_|_| |_| |_| .__/\n                                                   |_|\n"
+
+simulation: default_simulation
+

--- a/contribs/microStamp/samples/io/set_particle_type.msp
+++ b/contribs/microStamp/samples/io/set_particle_type.msp
@@ -17,12 +17,13 @@ input_data:
       xform: [ [ 1 , 0 , 0 ] , [ 0 , 1 , 0 ] , [ 0 , 0 , 1 ] ]
   - init_rcb_grid
   - particle_types:
-      particle_type_map: { A: 0 , B: 1 , C: 2 , D: 3}
+      particle_type_map: { A: 0 , B: 1 , C: 2 , D: 3 , E: 4 }
   - particle_type_add_properties:
       A: { radius: 1.0 ang , charge: 1 e- }
       B: { radius: 1.2 ang , test: 3 ang  }
       C: { radius: 0.7 ang , bibi: 2 eV  }      
-      D: { radius: 1.5 ang , bibi: 2 eV  }
+      D: { radius: 1.5 ang  }
+      E: { radius: 2.0 ang  }
   - particle_regions:
       - BOX:
           bounds: [ [ 25 ang , 25 ang , -100 ang ] , [ 50 ang , 120 ang , 100 ang ] ]
@@ -35,6 +36,12 @@ input_data:
               - scale: [ 20 ang , 50 ang , 20 ang ]
               - zrot: pi/4
               - translate: [ 120 ang , 130 ang , 0 ang ]
+      - CYL2:
+          quadric:
+            shape: cylz
+            transform:
+              - scale: [ 30 ang , 30 ang , 20 ang ]
+              - translate: [ 0 ang , 200 ang , 0 ang ]
   - lattice:
       structure: SC
       types: [ A ]
@@ -53,6 +60,10 @@ input_data:
       type: D
       region: BOX2
       fraction: 0.3
+  - set_particle_type:
+      type: E
+      region: CYL2
+      count: 500
       
 final_dump:
   - write_xyz:

--- a/src/compute/include/exanb/compute/gaussian_noise.h
+++ b/src/compute/include/exanb/compute/gaussian_noise.h
@@ -97,7 +97,7 @@ namespace exanb
 
     // optionaly limit noise to a geometric region
     ADD_SLOT( ParticleRegions    , particle_regions , INPUT , OPTIONAL );
-    ADD_SLOT( ParticleRegionCSG  , region           , INPUT_OUTPUT , OPTIONAL , DocString{"Region identifier or boolean expression with region identifiers to which the gaussian noise should be applied."} );
+    ADD_SLOT( ParticleRegionCSG  , region           , INPUT , OPTIONAL , DocString{"Region identifier or boolean expression with region identifiers to which the gaussian noise should be applied."} );
 
     // optionaly limit lattice generation to places where some mask has some value
     ADD_SLOT( GridCellValues     , grid_cell_values    , INPUT , OPTIONAL );

--- a/src/compute/include/exanb/compute/uniform_noise.h
+++ b/src/compute/include/exanb/compute/uniform_noise.h
@@ -67,7 +67,7 @@ namespace exanb
 
     // optionaly limit noise to a geometric region
     ADD_SLOT( ParticleRegions   , particle_regions , INPUT , OPTIONAL , DocString{"Region identifier or boolean expression with region identifiers to which the uniform noise should be applied."} );
-    ADD_SLOT( ParticleRegionCSG , region           , INPUT_OUTPUT , OPTIONAL );
+    ADD_SLOT( ParticleRegionCSG , region           , INPUT , OPTIONAL );
 
     // optionaly limit lattice generation to places where some mask has some value
     ADD_SLOT( GridCellValues , grid_cell_values    , INPUT , OPTIONAL );

--- a/src/grid_cell_particles/include/exanb/grid_cell_particles/particle_random_selection.h
+++ b/src/grid_cell_particles/include/exanb/grid_cell_particles/particle_random_selection.h
@@ -1,0 +1,168 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+#pragma once
+
+#include <onika/cuda/cuda.h>
+#include <cstdint>
+#include <cmath>
+#include <mpi.h>
+
+namespace exanb
+{
+
+  // ---------------------------------------------------------------------
+  // splitmix64 : small, fast, well distributed 64 bit integer hash.
+  // Used to turn (particle_id , seed) into a reproducible pseudo-random
+  // value, independent of particle ordering, MPI rank count or thread
+  // scheduling. Same id + seed always yields the same key, on CPU or GPU.
+  // ---------------------------------------------------------------------
+  ONIKA_HOST_DEVICE_FUNC inline uint64_t splitmix64( uint64_t x )
+  {
+    x += 0x9E3779B97F4A7C15ULL;
+    uint64_t z = x;
+    z = ( z ^ ( z >> 30 ) ) * 0xBF58476D1CE4E5B9ULL;
+    z = ( z ^ ( z >> 27 ) ) * 0x94D049BB133111EBULL;
+    return z ^ ( z >> 31 );
+  }
+
+  // deterministic pseudo-random key in [0,1) for a given particle id and seed
+  ONIKA_HOST_DEVICE_FUNC inline double particle_random_key( uint64_t id, uint64_t seed )
+  {
+    const uint64_t h = splitmix64( id ^ splitmix64( seed ) );
+    // keep the 53 most significant bits -> uniform double in [0,1)
+    return double( h >> 11 ) * ( 1.0 / 9007199254740992.0 /* 2^53 */ );
+  }
+
+  // ---------------------------------------------------------------------
+  // Describes how many particles (among those passing some spatial /
+  // logical filter) must be selected :
+  //  - ALL      : every eligible particle is selected (plain region selection)
+  //  - FRACTION : each eligible particle is selected independently with
+  //               probability = fraction. Cheap (single pass, no extra
+  //               communication), but the resulting count is only exact
+  //               in expectation.
+  //  - COUNT    : exactly (up to hash collisions, i.e. for all practical
+  //               purposes exactly) 'count' particles are selected globally,
+  //               across all MPI ranks, chosen uniformly at random among
+  //               eligible particles.
+  // ---------------------------------------------------------------------
+  struct ParticleSelectionCount
+  {
+    enum Mode { ALL = 0, FRACTION = 1, COUNT = 2 };
+    Mode mode = ALL;
+    double fraction = 1.0;
+    uint64_t count = 0;
+    uint64_t seed = 0;
+  };
+
+  struct ParticleSelectionThreshold
+  {
+    double tau = 1.0;              // select a particle if particle_random_key(id,seed) < tau
+    uint64_t global_eligible = 0;  // total nb of particles passing the spatial/logical filter, all ranks
+    uint64_t global_target = 0;    // nb of particles the selection is aiming for, all ranks
+  };
+
+  // Computes the selection threshold tau such that, among particles passing
+  // the caller's filter, testing (particle_random_key(id,seed) < tau) selects
+  // the number of particles requested by 'sel', globally across all ranks.
+  //
+  // The caller provides two local (rank-only) callbacks :
+  //   count_eligible()      -> nb of local particles passing the spatial/logical filter
+  //   count_below(tau)      -> nb of local eligible particles whose key < tau
+  //
+  // For FRACTION and ALL modes this only costs one MPI_Allreduce (to know
+  // how many particles are eligible in total). For COUNT mode, an extra
+  // bisection search on tau is run (each iteration costs one MPI_Allreduce
+  // of a local linear scan over already-filtered particles) until the global
+  // selected count matches the target exactly, or double precision is
+  // exhausted (~50 iterations, negligible compared to a typical particle count).
+  template<class CountEligibleFunc, class CountBelowThresholdFunc>
+  inline ParticleSelectionThreshold compute_particle_selection_threshold(
+        MPI_Comm comm,
+        const ParticleSelectionCount& sel,
+        CountEligibleFunc count_eligible,
+        CountBelowThresholdFunc count_below )
+  {
+    ParticleSelectionThreshold result;
+
+    const uint64_t local_eligible = count_eligible();
+    uint64_t global_eligible = 0;
+    MPI_Allreduce( (void*) &local_eligible, (void*) &global_eligible, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, comm );
+    result.global_eligible = global_eligible;
+
+    if( sel.mode == ParticleSelectionCount::ALL || global_eligible == 0 )
+    {
+      result.tau = 1.0;
+      result.global_target = global_eligible;
+      return result;
+    }
+
+    uint64_t target = 0;
+    if( sel.mode == ParticleSelectionCount::FRACTION )
+    {
+      const double f = sel.fraction < 0.0 ? 0.0 : ( sel.fraction > 1.0 ? 1.0 : sel.fraction );
+      target = static_cast<uint64_t>( std::llround( f * double(global_eligible) ) );
+    }
+    else // COUNT
+    {
+      target = sel.count;
+    }
+
+    if( target >= global_eligible )
+    {
+      result.tau = 1.0;
+      result.global_target = global_eligible;
+      return result;
+    }
+    if( target == 0 )
+    {
+      result.tau = 0.0;
+      result.global_target = 0;
+      return result;
+    }
+    result.global_target = target;
+
+    if( sel.mode == ParticleSelectionCount::FRACTION )
+    {
+      // single pass Bernoulli trial : expected count is exact, actual
+      // count may fluctuate slightly. No need for the bisection search.
+      result.tau = double(target) / double(global_eligible);
+      return result;
+    }
+
+    // COUNT mode : bisection search for the exact global count.
+    double lo = 0.0, hi = 1.0;
+    double tau = double(target) / double(global_eligible); // good initial guess
+    for( int it=0 ; it<64 ; it++ )
+    {
+      const uint64_t local_below = count_below( tau );
+      uint64_t global_below = 0;
+      MPI_Allreduce( (void*) &local_below, (void*) &global_below, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, comm );
+      if( global_below == target ) { lo = hi = tau; break; }
+      else if( global_below < target ) { lo = tau; }
+      else { hi = tau; }
+      const double next_tau = 0.5 * ( lo + hi );
+      if( next_tau == tau ) break; // double precision exhausted
+      tau = next_tau;
+    }
+    result.tau = tau;
+    return result;
+  }
+
+}

--- a/src/grid_cell_particles/set_particle_type.cpp
+++ b/src/grid_cell_particles/set_particle_type.cpp
@@ -1,0 +1,232 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+#include <onika/scg/operator.h>
+#include <onika/scg/operator_slot.h>
+#include <onika/scg/operator_factory.h>
+#include <onika/log.h>
+
+#include <exanb/core/grid.h>
+#include <exanb/core/domain.h>
+#include <exanb/core/xform.h>
+#include <exanb/core/make_grid_variant_operator.h>
+#include <exanb/core/parallel_grid_algorithm.h>
+#include <exanb/core/particle_type_id.h>
+
+#include <exanb/grid_cell_particles/particle_region.h>
+#include <exanb/grid_cell_particles/particle_localized_filter.h>
+#include <exanb/grid_cell_particles/particle_random_selection.h>
+
+#include <mpi.h>
+#include <atomic>
+#include <string>
+#include <cstdint>
+
+namespace exanb
+{
+
+  template<class GridT, class = AssertGridHasFields<GridT, field::_id, field::_type> >
+  class SetParticleType : public OperatorNode
+  {
+    ADD_SLOT( MPI_Comm          , mpi               , INPUT , MPI_COMM_WORLD );
+    ADD_SLOT( GridT             , grid              , INPUT_OUTPUT );
+    ADD_SLOT( Domain            , domain            , INPUT );
+
+    ADD_SLOT( ParticleTypeMap   , particle_type_map , INPUT , OPTIONAL , DocString{"Maps type names to internal integer ids. Required in order to resolve 'type' by name."} );
+    ADD_SLOT( std::string       , type              , INPUT , REQUIRED , DocString{"Name of the new particle type assigned to selected particles (looked up in particle_type_map)."} );
+
+    ADD_SLOT( ParticleRegions   , particle_regions  , INPUT , OPTIONAL );
+    ADD_SLOT( ParticleRegionCSG , region            , INPUT_OUTPUT , OPTIONAL , DocString{"Restricts candidate particles to this region (boolean expression over named particle_regions). If absent, the whole local domain is considered."} );
+
+    ADD_SLOT( double            , fraction          , INPUT , OPTIONAL , DocString{"Fraction (0..1) of eligible particles to convert, drawn at random. Mutually exclusive with 'count'."} );
+    ADD_SLOT( long               , count             , INPUT , OPTIONAL , DocString{"Exact number of eligible particles to convert, drawn at random, globally across all MPI ranks. Mutually exclusive with 'fraction'."} );
+    ADD_SLOT( long               , seed              , INPUT , 0 , DocString{"Seed for the deterministic random selection. Same seed + same particle ids => same selection, regardless of rank/thread count."} );
+    ADD_SLOT( bool               , ghost             , INPUT , false , DocString{"If true, ghost cells are processed too (rarely useful: ghosts get overwritten on the next ghost update)."} );
+
+  public:
+
+    inline std::string documentation() const override final
+    {
+      return R"EOF(
+Randomly reassigns the type of a subset of particles.
+
+Candidate ("eligible") particles can optionally be restricted to a spatial
+region via 'region' (a boolean expression over named 'particle_regions').
+Among the eligible particles, the ones actually converted are chosen either:
+  - all of them                     (neither 'fraction' nor 'count' given)
+  - a random fraction of them        ('fraction': 0..1, expected count only)
+  - an exact random number of them   ('count': exact, global across ranks)
+
+Selection is deterministic given 'seed' and particle ids: re-running the
+operator on the same grid with the same seed reproduces the same selection,
+independently of the number of MPI ranks or OpenMP threads.
+
+Usage examples:
+
+# convert every particle inside a region to type B
+  - set_particle_type:
+      region: INCLUSION
+      type: B
+
+# convert ~20% of the particles inside a region to type B
+  - set_particle_type:
+      region: INCLUSION
+      type: B
+      fraction: 0.2
+      seed: 42
+
+# convert exactly 5000 particles anywhere in the domain to type B
+  - set_particle_type:
+      type: B
+      count: 5000
+      seed: 42
+)EOF";
+    }
+
+    inline void execute() override final
+    {
+      if( fraction.has_value() && count.has_value() )
+      {
+        fatal_error() << "set_particle_type: 'fraction' and 'count' are mutually exclusive" << std::endl;
+      }
+      if( ! particle_type_map.has_value() )
+      {
+        fatal_error() << "set_particle_type: particle_type_map is undefined, cannot resolve type name '"<<(*type)<<"'" << std::endl;
+      }
+      const auto it = particle_type_map->find( *type );
+      if( it == particle_type_map->end() )
+      {
+        fatal_error() << "set_particle_type: unknown particle type '"<<(*type)<<"'" << std::endl;
+      }
+      const ParticleTypeInt new_type_id = static_cast<ParticleTypeInt>( it->second );
+
+      PartcileLocalizedFilter<GridT,LinearXForm> particle_filter = { *grid, { domain->xform() } };
+      particle_filter.initialize_from_optional_parameters( particle_regions.get_pointer(), region.get_pointer() );
+
+      ParticleSelectionCount sel;
+      sel.seed = static_cast<uint64_t>( *seed );
+      if( fraction.has_value() )      { sel.mode = ParticleSelectionCount::FRACTION; sel.fraction = *fraction; }
+      else if( count.has_value() )    { sel.mode = ParticleSelectionCount::COUNT;    sel.count    = static_cast<uint64_t>( *count ); }
+      else                            { sel.mode = ParticleSelectionCount::ALL; }
+      const uint64_t seedv = sel.seed;
+
+      auto cells = grid->cells();
+      const IJK dims = grid->dimension();
+      ssize_t gl = 0;
+      if( ! *ghost ) { gl = grid->ghost_layers(); }
+      const IJK gstart { gl, gl, gl };
+      const IJK gend = dims - IJK{ gl, gl, gl };
+      const IJK gdims = gend - gstart;
+
+      auto is_eligible = [&]( size_t cell_i, size_t p ) -> bool
+      {
+        const Vec3d r = { cells[cell_i][field::rx][p], cells[cell_i][field::ry][p], cells[cell_i][field::rz][p] };
+        const uint64_t id = cells[cell_i][field::id][p];
+        return particle_filter( r, id );
+      };
+
+      auto count_eligible = [&]() -> uint64_t
+      {
+        std::atomic<uint64_t> n = 0;
+#       pragma omp parallel
+        {
+          GRID_OMP_FOR_BEGIN(gdims,_,loc, schedule(dynamic) )
+          {
+            const size_t cell_i = grid_ijk_to_index( dims, loc + gstart );
+            const size_t np = cells[cell_i].size();
+            uint64_t local_n = 0;
+            for(size_t p=0;p<np;p++) { if( is_eligible(cell_i,p) ) ++local_n; }
+            n.fetch_add( local_n, std::memory_order_relaxed );
+          }
+          GRID_OMP_FOR_END
+        }
+        return n.load();
+      };
+
+      auto count_below = [&]( double tau ) -> uint64_t
+      {
+        std::atomic<uint64_t> n = 0;
+#       pragma omp parallel
+        {
+          GRID_OMP_FOR_BEGIN(gdims,_,loc, schedule(dynamic) )
+          {
+            const size_t cell_i = grid_ijk_to_index( dims, loc + gstart );
+            const size_t np = cells[cell_i].size();
+            uint64_t local_n = 0;
+            for(size_t p=0;p<np;p++)
+            {
+              if( is_eligible(cell_i,p) )
+              {
+                const uint64_t id = cells[cell_i][field::id][p];
+                if( particle_random_key(id,seedv) < tau ) ++local_n;
+              }
+            }
+            n.fetch_add( local_n, std::memory_order_relaxed );
+          }
+          GRID_OMP_FOR_END
+        }
+        return n.load();
+      };
+
+      const auto th = compute_particle_selection_threshold( *mpi, sel, count_eligible, count_below );
+
+      std::atomic<uint64_t> n_converted = 0;
+#     pragma omp parallel
+      {
+        GRID_OMP_FOR_BEGIN(gdims,_,loc, schedule(dynamic) )
+        {
+          const size_t cell_i = grid_ijk_to_index( dims, loc + gstart );
+          const size_t np = cells[cell_i].size();
+          uint64_t local_n = 0;
+          for(size_t p=0;p<np;p++)
+          {
+            if( is_eligible(cell_i,p) )
+            {
+              const uint64_t id = cells[cell_i][field::id][p];
+              if( particle_random_key(id,seedv) < th.tau )
+              {
+                cells[cell_i][field::type][p] = new_type_id;
+                ++local_n;
+              }
+            }
+          }
+          n_converted.fetch_add( local_n, std::memory_order_relaxed );
+        }
+        GRID_OMP_FOR_END
+      }
+
+      unsigned long long local_converted = n_converted.load();
+      unsigned long long global_converted = 0;
+      MPI_Allreduce( &local_converted, &global_converted, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, *mpi );
+
+      ldbg << "set_particle_type: eligible="<<th.global_eligible<<" target="<<th.global_target
+           <<" converted="<<global_converted<<" -> type '"<<(*type)<<"' (id="<<int(new_type_id)<<")"<<std::endl;
+    }
+
+  };
+
+  template<class GridT> using SetParticleTypeTmpl = SetParticleType<GridT>;
+
+  // === register factories ===
+  ONIKA_AUTORUN_INIT(set_particle_type)
+  {
+    OperatorNodeFactory::instance()->register_factory( "set_particle_type", make_grid_variant_operator< SetParticleTypeTmpl > );
+  }
+
+}

--- a/src/grid_cell_particles/set_particle_type.cpp
+++ b/src/grid_cell_particles/set_particle_type.cpp
@@ -55,9 +55,9 @@ namespace exanb
     ADD_SLOT( ParticleRegionCSG , region            , INPUT_OUTPUT , OPTIONAL , DocString{"Restricts candidate particles to this region (boolean expression over named particle_regions). If absent, the whole local domain is considered."} );
 
     ADD_SLOT( double            , fraction          , INPUT , OPTIONAL , DocString{"Fraction (0..1) of eligible particles to convert, drawn at random. Mutually exclusive with 'count'."} );
-    ADD_SLOT( long               , count             , INPUT , OPTIONAL , DocString{"Exact number of eligible particles to convert, drawn at random, globally across all MPI ranks. Mutually exclusive with 'fraction'."} );
-    ADD_SLOT( long               , seed              , INPUT , 0 , DocString{"Seed for the deterministic random selection. Same seed + same particle ids => same selection, regardless of rank/thread count."} );
-    ADD_SLOT( bool               , ghost             , INPUT , false , DocString{"If true, ghost cells are processed too (rarely useful: ghosts get overwritten on the next ghost update)."} );
+    ADD_SLOT( long              , count             , INPUT , OPTIONAL , DocString{"Exact number of eligible particles to convert, drawn at random, globally across all MPI ranks. Mutually exclusive with 'fraction'."} );
+    ADD_SLOT( long              , seed              , INPUT , 0 , DocString{"Seed for the deterministic random selection. Same seed + same particle ids => same selection, regardless of rank/thread count."} );
+    ADD_SLOT( bool              , ghost             , INPUT , false , DocString{"If true, ghost cells are processed too (rarely useful: ghosts get overwritten on the next ghost update)."} );
 
   public:
 

--- a/src/grid_cell_particles/set_particle_type.cpp
+++ b/src/grid_cell_particles/set_particle_type.cpp
@@ -52,7 +52,7 @@ namespace exanb
     ADD_SLOT( std::string       , type              , INPUT , REQUIRED , DocString{"Name of the new particle type assigned to selected particles (looked up in particle_type_map)."} );
 
     ADD_SLOT( ParticleRegions   , particle_regions  , INPUT , OPTIONAL );
-    ADD_SLOT( ParticleRegionCSG , region            , INPUT_OUTPUT , OPTIONAL , DocString{"Restricts candidate particles to this region (boolean expression over named particle_regions). If absent, the whole local domain is considered."} );
+    ADD_SLOT( ParticleRegionCSG , region            , INPUT , OPTIONAL , DocString{"Restricts candidate particles to this region (boolean expression over named particle_regions). If absent, the whole local domain is considered."} );
 
     ADD_SLOT( double            , fraction          , INPUT , OPTIONAL , DocString{"Fraction (0..1) of eligible particles to convert, drawn at random. Mutually exclusive with 'count'."} );
     ADD_SLOT( long              , count             , INPUT , OPTIONAL , DocString{"Exact number of eligible particles to convert, drawn at random, globally across all MPI ranks. Mutually exclusive with 'fraction'."} );


### PR DESCRIPTION
Randomly or fully reassigns the type of a subset of particles inside a named region or everywhere. See example and description below:

<img width="400" height="400" alt="set_particle_type_example" src="https://github.com/user-attachments/assets/7a417a4b-730c-4cee-bb72-0e00bdbf3bbc" />

Candidate ("eligible") particles can optionally be restricted to a spatial region via 'region' (a boolean expression over named 'particle_regions'). Among the eligible particles, the ones actually converted are chosen either:
  - all of them                     (neither 'fraction' nor 'count' given)
  - a random fraction of them        ('fraction': 0..1, expected count only)
  - an exact random number of them   ('count': exact, global across ranks)

Selection is deterministic given 'seed' and particle ids: re-running the operator on the same grid with the same seed reproduces the same selection, independently of the number of MPI ranks or OpenMP threads.

Usage examples:

```yaml
# convert every particle inside a region to type B
  - set_particle_type:
      region: INCLUSION
      type: B

# convert ~20% of the particles inside a region to type B
  - set_particle_type:
      region: INCLUSION
      type: B
      fraction: 0.2
      seed: 42

# convert exactly 5000 particles anywhere in the domain to type B
  - set_particle_type:
      type: B
      count: 5000
      seed: 42
```

Here's a full example that generates the image below:
```yaml
global:
  dt: 1.0e-5 ps
  rcut_max: 4.0 ang
  rcut_inc: 1.0 ang
  simulation_log_frequency: 1
  simulation_end_iteration: 1

compute_force: nop

input_data:
  - domain:
      cell_size: 10.0 ang
      grid_dims: [ 20 , 20 , 2 ]
      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 200.0 ang , 200.0 ang , 20.0 ang ] ]
      periodic: [ true , true , true ]
      expandable: false
      xform: [ [ 1 , 0 , 0 ] , [ 0 , 1 , 0 ] , [ 0 , 0 , 1 ] ]
  - init_rcb_grid
  - particle_types:
      particle_type_map: { A: 0 , B: 1 , C: 2 , D: 3 , E: 4 }
  - particle_type_add_properties:
      A: { radius: 1.0 ang , charge: 1 e- }
      B: { radius: 1.2 ang , test: 3 ang  }
      C: { radius: 0.7 ang , bibi: 2 eV  }      
      D: { radius: 1.5 ang  }
      E: { radius: 2.0 ang  }
  - particle_regions:
      - BOX:
          bounds: [ [ 25 ang , 25 ang , -100 ang ] , [ 50 ang , 120 ang , 100 ang ] ]
      - BOX2:
          bounds: [ [ 75 ang , 5 ang , -100 ang ] , [ 180 ang , 35 ang , 100 ang ] ]
      - CYL:
          quadric:
            shape: cylz
            transform:
              - scale: [ 20 ang , 50 ang , 20 ang ]
              - zrot: pi/4
              - translate: [ 120 ang , 130 ang , 0 ang ]
      - CYL2:
          quadric:
            shape: cylz
            transform:
              - scale: [ 30 ang , 30 ang , 20 ang ]
              - translate: [ 0 ang , 200 ang , 0 ang ]
  - lattice:
      structure: SC
      types: [ A ]
      size: [ 2.5 ang , 2.5 ang , 2.5 ang ]
  - gaussian_noise_r:
      sigma: 0.5 ang
      sigma_cut: 0.4 ang
  - set_particle_type:
      type: B
      seed: 432
      region: BOX
  - set_particle_type:
      type: C
      region: CYL
  - set_particle_type:
      type: D
      region: BOX2
      fraction: 0.3
  - set_particle_type:
      type: E
      region: CYL2
      count: 500
      
final_dump:
  - write_xyz:
      filename: "test_set_particle_type.xyz"
      fields: [ id , type , radius , charge , bibi , test ]

simulation: default_simulation
```
