### PR TITLE
154 remove particles operator

### DIFF
--- a/contribs/microStamp/samples/io/remove_close_particles.msp
+++ b/contribs/microStamp/samples/io/remove_close_particles.msp
@@ -1,0 +1,63 @@
+configuration:
+  physics:
+    units:
+      length: angstrom
+      mass: Dalton
+      time: picosecond
+      charge: elementary_charge
+      temperature: kelvin
+      amount: particle
+      luminosity: candela
+      angle: radian
+      energy: joule
+
+global:
+  dt: 1.0e-5 ps
+  rcut_max: 4.0 ang
+  rcut_inc: 1.0 ang
+  simulation_log_frequency: 1
+  simulation_end_iteration: 1
+
+compute_force: nop
+
+input_data:
+  - domain:
+      cell_size: 10.0 ang
+      grid_dims: [ 3 , 3 , 3 ]
+      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 30.0 ang , 30.0 ang , 30.0 ang ] ]
+      periodic: [ true , true , true ]
+      expandable: false
+      xform: [ [ 1 , 0 , 0 ] , [ 0 , 1 , 0 ] , [ 0 , 0 , 1 ] ]
+  - init_rcb_grid
+  - particle_types:
+      particle_type_map: { A: 0 , B: 1 }
+  - particle_type_add_properties:
+      A: { mass: 30 Da , radius: 1.0 ang , charge: 0 e- }
+      B: { mass: 30 Da , radius: 1.0 ang , charge: 0 e- }
+  - lattice:
+      structure: SC
+      types: [ A ]
+      size: [ 6 ang , 6 ang , 6 ang ]
+  - lattice:
+      structure: SC
+      types: [ B ]
+      size: [ 6 ang , 6 ang , 6 ang ]
+      shift: [ 2 ang , 2 ang , 0 ang ]
+  - gaussian_noise_r:
+      sigma: 0.1 ang
+      sigma_cut: 1. ang
+      
++first_iteration:
+  - write_xyz:
+      filename: "test_1.xyz"
+      fields: [ id , type ]
+  - remove_close_particles:
+      distance: 3.5 ang
+  - write_xyz:
+      filename: "test_2.xyz"
+      fields: [ id , type ]
+
+final_dump: nop
+
+simulation: default_simulation
+

--- a/contribs/microStamp/samples/io/remove_close_particles_large.msp
+++ b/contribs/microStamp/samples/io/remove_close_particles_large.msp
@@ -1,0 +1,64 @@
+configuration:
+  physics:
+    units:
+      length: angstrom
+      mass: Dalton
+      time: picosecond
+      charge: elementary_charge
+      temperature: kelvin
+      amount: particle
+      luminosity: candela
+      angle: radian
+      energy: joule
+
+global:
+  dt: 1.0e-5 ps
+  rcut_max: 4.0 ang
+  rcut_inc: 1.0 ang
+  simulation_log_frequency: 1
+  simulation_end_iteration: 1
+
+compute_force: nop
+
+input_data:
+  - domain:
+      cell_size: 10.0 ang
+      grid_dims: [ 3 , 3 , 3 ]
+      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 30.0 ang , 30.0 ang , 30.0 ang ] ]
+      periodic: [ true , true , true ]
+      expandable: false
+      xform: [ [ 1 , 0 , 0 ] , [ 0 , 1 , 0 ] , [ 0 , 0 , 1 ] ]
+  - init_rcb_grid
+  - particle_types:
+      particle_type_map: { A: 0 , B: 1 }
+  - particle_type_add_properties:
+      A: { mass: 30 Da , radius: 1.0 ang , charge: 0 e- }
+      B: { mass: 30 Da , radius: 1.0 ang , charge: 0 e- }
+  - lattice:
+      structure: BCC
+      types: [ A , B ]
+      size: [ 3 ang , 3 ang , 3 ang ]
+  - gaussian_noise_r:
+      sigma: 0.25 ang
+      
++first_iteration:
+  - write_xyz:
+      filename: "test_bis_1.xyz"
+      fields: [ id , type ]
+  - remove_close_particles:
+      distance: 2.5 ang
+  - compact_particle_ids
+  - move_particles
+  - parallel_update_particles
+  - write_xyz:
+      filename: "test_bis_2.xyz"
+      fields: [ id , type ]
+  - remove_close_particles:
+      distance: 3.5 ang
+  - write_xyz:
+      filename: "test_bis_3.xyz"
+      fields: [ id , type ]
+
+final_dump: nop
+
+simulation: default_simulation

--- a/contribs/microStamp/samples/io/remove_particles.msp
+++ b/contribs/microStamp/samples/io/remove_particles.msp
@@ -1,0 +1,90 @@
+configuration:
+  physics:
+    units:
+      length: angstrom
+      mass: Dalton
+      time: picosecond
+      charge: elementary_charge
+      temperature: kelvin
+      amount: particle
+      luminosity: candela
+      angle: radian
+      energy: joule
+  logging:
+    debug: false
+    parallel: true
+  onika:
+    gpu_block_dims: [ 1 , 1 , 1 ]
+
+global:
+  dt: 1.0e-5 ps
+  rcut_max: 8.0 ang
+  rcut_inc: 1.0 ang # additional distance so that we d'ont have to rebuild neighbor list each time step
+  simulation_log_frequency: 1
+  simulation_end_iteration: 1
+
+compute_force: nop
+
+input_data:
+  - particle_types:
+      particle_type_map: { A: 0 , B: 1 , C: 2 }
+  - particle_regions:
+      - PLANE1:
+          quadric:
+            shape: { plane: [ 1 , 0 , 0 , 0 ] }
+            transform:
+              - zrot: pi/4
+              - translate: [ 20 ang , 150 ang , 0 ]
+      - PLANE2:
+          quadric:
+            shape: { plane: [ 1 , 0 , 0 , 0 ] }
+            transform:
+              - zrot: -pi/4
+              - translate: [ 20 ang , 150 ang , 0 ]
+      - BOX:
+          bounds: [ [ 250 ang , 0 ang , 0 ang ] , [ 300 ang , 300 ang , 300 ang ] ]
+      - SPHERE:
+          quadric:
+            shape: sphere
+            transform:
+              - scale: [ 20 ang , 20 ang , 20 ang ] 
+              - translate: [ 150 ang , 150 ang , 150 ang ]
+  - domain:
+      cell_size: 30.0 ang
+      grid_dims: [ 10 , 10 , 10 ]
+      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 300.0 ang , 300.0 ang , 300.0 ang ] ]
+      periodic: [ true , true , true ]
+      expandable: false
+      xform: [ [ 1 , 0 , 0 ] , [ 0 , 1 , 0 ] , [ 0 , 0 , 1 ] ]
+  - init_rcb_grid
+  - lattice:
+      structure: SC
+      types: [ A ]
+      size: [ 3. ang , 3. ang , 3. ang ]
+  - gaussian_noise_r:
+      sigma: 0.1 ang
+      sigma_cut: 0.4 ang
+      region: PLANE1 or PLANE2 or BOX or SPHERE
+  - lattice:
+      structure: BCC
+      types: [ B , C ]
+      size: [ 15. ang , 15. ang , 15. ang ]
+  - remove_particles:
+      region: not ( PLANE1 or PLANE2 or BOX or SPHERE )
+  - compact_particle_ids
+  - remove_particles:
+      fraction: 0.7
+      seed: 3284
+  - compact_particle_ids
+
+final_dump:
+  - write_xyz:
+      filename: "remove_particles.xyz"
+      fields: [ id , type ]
+
+# pretty logo banner
+logo_banner:
+  - message: "           _               ____  _\n _ __ ___ (_) ___ _ __ ___/ ___|| |_ __ _ _ __ ___  _ __\n| '_ ` _ \\| |/ __| '__/ _ \\___ \\| __/ _` | '_ ` _ \\| '_ \\\n| | | | | | | (__| | | (_) |__) | || (_| | | | | | | |_) |\n|_| |_| |_|_|\\___|_|  \\___/____/ \\__\\__,_|_| |_| |_| .__/\n                                                   |_|\n"
+
+simulation: default_simulation
+

--- a/contribs/microStamp/samples/io/remove_particles.msp
+++ b/contribs/microStamp/samples/io/remove_particles.msp
@@ -10,81 +10,73 @@ configuration:
       luminosity: candela
       angle: radian
       energy: joule
-  logging:
-    debug: false
-    parallel: true
-  onika:
-    gpu_block_dims: [ 1 , 1 , 1 ]
 
 global:
   dt: 1.0e-5 ps
-  rcut_max: 8.0 ang
-  rcut_inc: 1.0 ang # additional distance so that we d'ont have to rebuild neighbor list each time step
+  rcut_max: 4.0 ang
+  rcut_inc: 1.0 ang
   simulation_log_frequency: 1
   simulation_end_iteration: 1
 
 compute_force: nop
 
 input_data:
-  - particle_types:
-      particle_type_map: { A: 0 , B: 1 , C: 2 }
-  - particle_regions:
-      - PLANE1:
-          quadric:
-            shape: { plane: [ 1 , 0 , 0 , 0 ] }
-            transform:
-              - zrot: pi/4
-              - translate: [ 20 ang , 150 ang , 0 ]
-      - PLANE2:
-          quadric:
-            shape: { plane: [ 1 , 0 , 0 , 0 ] }
-            transform:
-              - zrot: -pi/4
-              - translate: [ 20 ang , 150 ang , 0 ]
-      - BOX:
-          bounds: [ [ 250 ang , 0 ang , 0 ang ] , [ 300 ang , 300 ang , 300 ang ] ]
-      - SPHERE:
-          quadric:
-            shape: sphere
-            transform:
-              - scale: [ 20 ang , 20 ang , 20 ang ] 
-              - translate: [ 150 ang , 150 ang , 150 ang ]
   - domain:
-      cell_size: 30.0 ang
-      grid_dims: [ 10 , 10 , 10 ]
-      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 300.0 ang , 300.0 ang , 300.0 ang ] ]
+      cell_size: 10.0 ang
+      grid_dims: [ 20 , 20 , 2 ]
+      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 200.0 ang , 200.0 ang , 20.0 ang ] ]
       periodic: [ true , true , true ]
       expandable: false
       xform: [ [ 1 , 0 , 0 ] , [ 0 , 1 , 0 ] , [ 0 , 0 , 1 ] ]
   - init_rcb_grid
+  - particle_types:
+      particle_type_map: { A: 0 }
+  - particle_type_add_properties:
+      A: { mass: 30 Da , radius: 1.0 ang , charge: 0 e- }
+  - particle_regions:
+      - BOX:
+          bounds: [ [ 25 ang , 25 ang , -100 ang ] , [ 50 ang , 120 ang , 100 ang ] ]
+      - BOX2:
+          bounds: [ [ 75 ang , 5 ang , -100 ang ] , [ 180 ang , 35 ang , 100 ang ] ]
+      - CYL:
+          quadric:
+            shape: cylz
+            transform:
+              - scale: [ 20 ang , 50 ang , 20 ang ]
+              - zrot: pi/4
+              - translate: [ 120 ang , 130 ang , 0 ang ]
+      - CYL2:
+          quadric:
+            shape: cylz
+            transform:
+              - scale: [ 30 ang , 30 ang , 20 ang ]
+              - translate: [ 0 ang , 200 ang , 0 ang ]
   - lattice:
       structure: SC
       types: [ A ]
-      size: [ 3. ang , 3. ang , 3. ang ]
+      size: [ 2.5 ang , 2.5 ang , 2.5 ang ]
   - gaussian_noise_r:
-      sigma: 0.1 ang
+      sigma: 0.5 ang
       sigma_cut: 0.4 ang
-      region: PLANE1 or PLANE2 or BOX or SPHERE
-  - lattice:
-      structure: BCC
-      types: [ B , C ]
-      size: [ 15. ang , 15. ang , 15. ang ]
   - remove_particles:
-      region: not ( PLANE1 or PLANE2 or BOX or SPHERE )
-  - compact_particle_ids
+      region: BOX
+#  - compact_particle_ids
   - remove_particles:
-      fraction: 0.7
-      seed: 3284
-  - compact_particle_ids
-
+      region: CYL
+#  - compact_particle_ids
+  - remove_particles:
+      region: BOX2
+      fraction: 0.3
+#  - compact_particle_ids
+  - remove_particles:
+      region: CYL2
+      count: 500
+#  - compact_particle_ids
+      
 final_dump:
   - write_xyz:
-      filename: "remove_particles.xyz"
-      fields: [ id , type ]
-
-# pretty logo banner
-logo_banner:
-  - message: "           _               ____  _\n _ __ ___ (_) ___ _ __ ___/ ___|| |_ __ _ _ __ ___  _ __\n| '_ ` _ \\| |/ __| '__/ _ \\___ \\| __/ _` | '_ ` _ \\| '_ \\\n| | | | | | | (__| | | (_) |__) | || (_| | | | | | | |_) |\n|_| |_| |_|_|\\___|_|  \\___/____/ \\__\\__,_|_| |_| |_| .__/\n                                                   |_|\n"
+      filename: "test_remove_particles.xyz"
+      fields: [ id , type , mass ]
 
 simulation: default_simulation
 

--- a/contribs/microStamp/samples/io/remove_particles.msp
+++ b/contribs/microStamp/samples/io/remove_particles.msp
@@ -60,18 +60,18 @@ input_data:
       sigma_cut: 0.4 ang
   - remove_particles:
       region: BOX
-#  - compact_particle_ids
+  - compact_particle_ids
   - remove_particles:
       region: CYL
-#  - compact_particle_ids
+  - compact_particle_ids
   - remove_particles:
       region: BOX2
       fraction: 0.3
-#  - compact_particle_ids
+  - compact_particle_ids
   - remove_particles:
       region: CYL2
       count: 500
-#  - compact_particle_ids
+  - compact_particle_ids
       
 final_dump:
   - write_xyz:

--- a/contribs/microStamp/samples/io/remove_particles_in_movement.msp
+++ b/contribs/microStamp/samples/io/remove_particles_in_movement.msp
@@ -1,0 +1,79 @@
+configuration:
+  physics:
+    units:
+      length: angstrom
+      mass: Dalton
+      time: picosecond
+      charge: elementary_charge
+      temperature: kelvin
+      amount: particle
+      luminosity: candela
+      angle: radian
+      energy: joule
+
+global:
+  dt: 1.0e-3 ps
+  rcut_max: 4.0 ang
+  rcut_inc: 1.0 ang
+  simulation_log_frequency: 10
+  simulation_dump_frequency: 50
+  simulation_end_iteration: 2000
+  delete_particles_frequency: 10
+  
+trigger_delete_particles:
+  rebind: { freq: delete_particles_frequency , result: trigger_delete_particles }
+  body:
+    - nth_timestep: { first: false }
+  
+delete_particles:
+  condition: trigger_delete_particles
+  body:
+  - remove_particles:
+      region: PLANE
+  - compact_particle_ids
+  - move_particles
+  - parallel_update_particles
+  
+compute_force:
+  - trigger_delete_particles
+  - delete_particles
+ 
+input_data:
+  - domain:
+      cell_size: 10.0 ang
+      grid_dims: [ 10 , 5 , 5 ]
+      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 100.0 ang , 50.0 ang , 50.0 ang ] ]
+      periodic: [ true , true , true ]
+      expandable: false
+      xform: [ [ 1 , 0 , 0 ] , [ 0 , 1 , 0 ] , [ 0 , 0 , 1 ] ]
+  - init_rcb_grid
+  - particle_types:
+      particle_type_map: { A: 0 }
+  - particle_type_add_properties:
+      A: { mass: 30 Da , radius: 1.0 ang , charge: 0 e- }
+  - particle_regions:
+      - BOX:
+          bounds: [ [ 0 ang , 0 ang , 0 ang ] , [ 50 ang , 50 ang , 50 ang ] ]
+      - PLANE:
+          quadric:
+            shape: { plane: [ -1 , 0 , 0 , 0 ] }
+            transform:
+              - translate: [ 50 ang , 0 , 0 ]
+  - lattice:
+      structure: SC
+      types: [ A ]
+      size: [ 2.5 ang , 2.5 ang , 2.5 ang ]
+      region: BOX
+  - gaussian_noise_r:
+      sigma: 0.5 ang
+      sigma_cut: 0.4 ang
+  - shift_v:
+      value: [ 1000 m/s , 0 , 0 ]
+      
+dump_data:
+  - timestep_file: "test_no_remove_particles_in_movement_%09d.xyz"
+  - write_xyz:
+      fields: [ id , type , mass ]
+
+simulation: default_simulation
+

--- a/contribs/microStamp/samples/io/set_particle_type.msp
+++ b/contribs/microStamp/samples/io/set_particle_type.msp
@@ -1,91 +1,63 @@
-configuration:
-  physics:
-    units:
-      length: angstrom
-      mass: Dalton
-      time: picosecond
-      charge: elementary_charge
-      temperature: kelvin
-      amount: particle
-      luminosity: candela
-      angle: radian
-      energy: joule
-  logging:
-    debug: false
-    parallel: true
-  onika:
-    gpu_block_dims: [ 1 , 1 , 1 ]
-
 global:
   dt: 1.0e-5 ps
-  rcut_max: 8.0 ang
-  rcut_inc: 1.0 ang # additional distance so that we d'ont have to rebuild neighbor list each time step
+  rcut_max: 4.0 ang
+  rcut_inc: 1.0 ang
   simulation_log_frequency: 1
   simulation_end_iteration: 1
 
 compute_force: nop
 
 input_data:
-  - particle_types:
-      particle_type_map: { A: 0 , B: 1 , C: 2 }
-  - particle_type_add_properties:
-      A: { radius: 1.5 ang , charge: 1 e- }
-      B: { radius: 2.0 ang , test: 3 ang  }
-      C: { radius: 2.5 ang , bibi: 2 eV  }      
-  - particle_regions:
-      - PLANE1:
-          quadric:
-            shape: { plane: [ 1 , 0 , 0 , 0 ] }
-            transform:
-              - zrot: pi/4
-              - translate: [ 20 ang , 150 ang , 0 ]
-      - PLANE2:
-          quadric:
-            shape: { plane: [ 1 , 0 , 0 , 0 ] }
-            transform:
-              - zrot: -pi/4
-              - translate: [ 20 ang , 150 ang , 0 ]
-      - BOX:
-          bounds: [ [ 250 ang , 0 ang , 0 ang ] , [ 300 ang , 300 ang , 300 ang ] ]
-      - SPHERE:
-          quadric:
-            shape: sphere
-            transform:
-              - scale: [ 20 ang , 20 ang , 20 ang ] 
-              - translate: [ 150 ang , 150 ang , 150 ang ]
   - domain:
-      cell_size: 30.0 ang
-      grid_dims: [ 10 , 10 , 10 ]
-      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 300.0 ang , 300.0 ang , 300.0 ang ] ]
+      cell_size: 10.0 ang
+      grid_dims: [ 20 , 20 , 2 ]
+      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 200.0 ang , 200.0 ang , 20.0 ang ] ]
       periodic: [ true , true , true ]
       expandable: false
       xform: [ [ 1 , 0 , 0 ] , [ 0 , 1 , 0 ] , [ 0 , 0 , 1 ] ]
   - init_rcb_grid
+  - particle_types:
+      particle_type_map: { A: 0 , B: 1 , C: 2 , D: 3}
+  - particle_type_add_properties:
+      A: { radius: 1.0 ang , charge: 1 e- }
+      B: { radius: 1.2 ang , test: 3 ang  }
+      C: { radius: 0.7 ang , bibi: 2 eV  }      
+      D: { radius: 1.5 ang , bibi: 2 eV  }
+  - particle_regions:
+      - BOX:
+          bounds: [ [ 25 ang , 25 ang , -100 ang ] , [ 50 ang , 120 ang , 100 ang ] ]
+      - BOX2:
+          bounds: [ [ 75 ang , 5 ang , -100 ang ] , [ 180 ang , 35 ang , 100 ang ] ]
+      - CYL:
+          quadric:
+            shape: cylz
+            transform:
+              - scale: [ 20 ang , 50 ang , 20 ang ]
+              - zrot: pi/4
+              - translate: [ 120 ang , 130 ang , 0 ang ]
   - lattice:
       structure: SC
       types: [ A ]
-      size: [ 3. ang , 3. ang , 3. ang ]
+      size: [ 2.5 ang , 2.5 ang , 2.5 ang ]
   - gaussian_noise_r:
-      sigma: 0.1 ang
+      sigma: 0.5 ang
       sigma_cut: 0.4 ang
-      region: PLANE1 or PLANE2 or BOX or SPHERE
   - set_particle_type:
       type: B
-      fraction: 0.1
       seed: 432
+      region: BOX
   - set_particle_type:
-      region: SPHERE
       type: C
-      fraction: 0.5
+      region: CYL
+  - set_particle_type:
+      type: D
+      region: BOX2
+      fraction: 0.3
       
 final_dump:
   - write_xyz:
       filename: "test_set_particle_type.xyz"
       fields: [ id , type , radius , charge , bibi , test ]
-
-# pretty logo banner
-logo_banner:
-  - message: "           _               ____  _\n _ __ ___ (_) ___ _ __ ___/ ___|| |_ __ _ _ __ ___  _ __\n| '_ ` _ \\| |/ __| '__/ _ \\___ \\| __/ _` | '_ ` _ \\| '_ \\\n| | | | | | | (__| | | (_) |__) | || (_| | | | | | | |_) |\n|_| |_| |_|_|\\___|_|  \\___/____/ \\__\\__,_|_| |_| |_| .__/\n                                                   |_|\n"
 
 simulation: default_simulation
 

--- a/contribs/microStamp/samples/io/set_particle_type.msp
+++ b/contribs/microStamp/samples/io/set_particle_type.msp
@@ -28,6 +28,10 @@ compute_force: nop
 input_data:
   - particle_types:
       particle_type_map: { A: 0 , B: 1 , C: 2 }
+  - particle_type_add_properties:
+      A: { radius: 1.5 ang , charge: 1 e- }
+      B: { radius: 2.0 ang , test: 3 ang  }
+      C: { radius: 2.5 ang , bibi: 2 eV  }      
   - particle_regions:
       - PLANE1:
           quadric:
@@ -77,7 +81,7 @@ input_data:
 final_dump:
   - write_xyz:
       filename: "test_set_particle_type.xyz"
-      fields: [ id , type ]
+      fields: [ id , type , radius , charge , bibi , test ]
 
 # pretty logo banner
 logo_banner:

--- a/contribs/microStamp/samples/io/set_particle_type.msp
+++ b/contribs/microStamp/samples/io/set_particle_type.msp
@@ -1,0 +1,87 @@
+configuration:
+  physics:
+    units:
+      length: angstrom
+      mass: Dalton
+      time: picosecond
+      charge: elementary_charge
+      temperature: kelvin
+      amount: particle
+      luminosity: candela
+      angle: radian
+      energy: joule
+  logging:
+    debug: false
+    parallel: true
+  onika:
+    gpu_block_dims: [ 1 , 1 , 1 ]
+
+global:
+  dt: 1.0e-5 ps
+  rcut_max: 8.0 ang
+  rcut_inc: 1.0 ang # additional distance so that we d'ont have to rebuild neighbor list each time step
+  simulation_log_frequency: 1
+  simulation_end_iteration: 1
+
+compute_force: nop
+
+input_data:
+  - particle_types:
+      particle_type_map: { A: 0 , B: 1 , C: 2 }
+  - particle_regions:
+      - PLANE1:
+          quadric:
+            shape: { plane: [ 1 , 0 , 0 , 0 ] }
+            transform:
+              - zrot: pi/4
+              - translate: [ 20 ang , 150 ang , 0 ]
+      - PLANE2:
+          quadric:
+            shape: { plane: [ 1 , 0 , 0 , 0 ] }
+            transform:
+              - zrot: -pi/4
+              - translate: [ 20 ang , 150 ang , 0 ]
+      - BOX:
+          bounds: [ [ 250 ang , 0 ang , 0 ang ] , [ 300 ang , 300 ang , 300 ang ] ]
+      - SPHERE:
+          quadric:
+            shape: sphere
+            transform:
+              - scale: [ 20 ang , 20 ang , 20 ang ] 
+              - translate: [ 150 ang , 150 ang , 150 ang ]
+  - domain:
+      cell_size: 30.0 ang
+      grid_dims: [ 10 , 10 , 10 ]
+      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 300.0 ang , 300.0 ang , 300.0 ang ] ]
+      periodic: [ true , true , true ]
+      expandable: false
+      xform: [ [ 1 , 0 , 0 ] , [ 0 , 1 , 0 ] , [ 0 , 0 , 1 ] ]
+  - init_rcb_grid
+  - lattice:
+      structure: SC
+      types: [ A ]
+      size: [ 3. ang , 3. ang , 3. ang ]
+  - gaussian_noise_r:
+      sigma: 0.1 ang
+      sigma_cut: 0.4 ang
+      region: PLANE1 or PLANE2 or BOX or SPHERE
+  - set_particle_type:
+      type: B
+      fraction: 0.1
+      seed: 432
+  - set_particle_type:
+      region: SPHERE
+      type: C
+      fraction: 0.5
+      
+final_dump:
+  - write_xyz:
+      filename: "test_set_particle_type.xyz"
+      fields: [ id , type ]
+
+# pretty logo banner
+logo_banner:
+  - message: "           _               ____  _\n _ __ ___ (_) ___ _ __ ___/ ___|| |_ __ _ _ __ ___  _ __\n| '_ ` _ \\| |/ __| '__/ _ \\___ \\| __/ _` | '_ ` _ \\| '_ \\\n| | | | | | | (__| | | (_) |__) | || (_| | | | | | | |_) |\n|_| |_| |_|_|\\___|_|  \\___/____/ \\__\\__,_|_| |_| |_| .__/\n                                                   |_|\n"
+
+simulation: default_simulation
+

--- a/contribs/microStamp/samples/io/set_particle_type.msp
+++ b/contribs/microStamp/samples/io/set_particle_type.msp
@@ -17,12 +17,13 @@ input_data:
       xform: [ [ 1 , 0 , 0 ] , [ 0 , 1 , 0 ] , [ 0 , 0 , 1 ] ]
   - init_rcb_grid
   - particle_types:
-      particle_type_map: { A: 0 , B: 1 , C: 2 , D: 3}
+      particle_type_map: { A: 0 , B: 1 , C: 2 , D: 3 , E: 4 }
   - particle_type_add_properties:
       A: { radius: 1.0 ang , charge: 1 e- }
       B: { radius: 1.2 ang , test: 3 ang  }
       C: { radius: 0.7 ang , bibi: 2 eV  }      
-      D: { radius: 1.5 ang , bibi: 2 eV  }
+      D: { radius: 1.5 ang  }
+      E: { radius: 2.0 ang  }
   - particle_regions:
       - BOX:
           bounds: [ [ 25 ang , 25 ang , -100 ang ] , [ 50 ang , 120 ang , 100 ang ] ]
@@ -35,6 +36,12 @@ input_data:
               - scale: [ 20 ang , 50 ang , 20 ang ]
               - zrot: pi/4
               - translate: [ 120 ang , 130 ang , 0 ang ]
+      - CYL2:
+          quadric:
+            shape: cylz
+            transform:
+              - scale: [ 30 ang , 30 ang , 20 ang ]
+              - translate: [ 0 ang , 200 ang , 0 ang ]
   - lattice:
       structure: SC
       types: [ A ]
@@ -53,6 +60,10 @@ input_data:
       type: D
       region: BOX2
       fraction: 0.3
+  - set_particle_type:
+      type: E
+      region: CYL2
+      count: 500
       
 final_dump:
   - write_xyz:

--- a/src/compute/include/exanb/compute/gaussian_noise.h
+++ b/src/compute/include/exanb/compute/gaussian_noise.h
@@ -97,7 +97,7 @@ namespace exanb
 
     // optionaly limit noise to a geometric region
     ADD_SLOT( ParticleRegions    , particle_regions , INPUT , OPTIONAL );
-    ADD_SLOT( ParticleRegionCSG  , region           , INPUT_OUTPUT , OPTIONAL , DocString{"Region identifier or boolean expression with region identifiers to which the gaussian noise should be applied."} );
+    ADD_SLOT( ParticleRegionCSG  , region           , INPUT , OPTIONAL , DocString{"Region identifier or boolean expression with region identifiers to which the gaussian noise should be applied."} );
 
     // optionaly limit lattice generation to places where some mask has some value
     ADD_SLOT( GridCellValues     , grid_cell_values    , INPUT , OPTIONAL );

--- a/src/compute/include/exanb/compute/uniform_noise.h
+++ b/src/compute/include/exanb/compute/uniform_noise.h
@@ -67,7 +67,7 @@ namespace exanb
 
     // optionaly limit noise to a geometric region
     ADD_SLOT( ParticleRegions   , particle_regions , INPUT , OPTIONAL , DocString{"Region identifier or boolean expression with region identifiers to which the uniform noise should be applied."} );
-    ADD_SLOT( ParticleRegionCSG , region           , INPUT_OUTPUT , OPTIONAL );
+    ADD_SLOT( ParticleRegionCSG , region           , INPUT , OPTIONAL );
 
     // optionaly limit lattice generation to places where some mask has some value
     ADD_SLOT( GridCellValues , grid_cell_values    , INPUT , OPTIONAL );

--- a/src/grid_cell_particles/CMakeLists.txt
+++ b/src/grid_cell_particles/CMakeLists.txt
@@ -19,5 +19,6 @@
 # === micro-stamp pair potential compute operator library library  ===
 # ====================================================================
 
+set(exanbGridCellParticles_LINK_LIBRARIES exanbParticleNeighbors)
 xnb_add_plugin(exanbGridCellParticles ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/grid_cell_particles/compact_particle_ids.cpp
+++ b/src/grid_cell_particles/compact_particle_ids.cpp
@@ -1,0 +1,144 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+#include <onika/scg/operator.h>
+#include <onika/scg/operator_slot.h>
+#include <onika/scg/operator_factory.h>
+#include <onika/log.h>
+
+#include <exanb/core/grid.h>
+#include <exanb/core/make_grid_variant_operator.h>
+#include <exanb/core/parallel_grid_algorithm.h>
+
+#include <mpi.h>
+#include <vector>
+#include <cstdint>
+
+namespace exanb
+{
+
+  template<class GridT, class = AssertGridHasFields<GridT, field::_id> >
+  class CompactParticleIds : public OperatorNode
+  {
+    ADD_SLOT( MPI_Comm , mpi  , INPUT , MPI_COMM_WORLD );
+    ADD_SLOT( GridT    , grid , INPUT_OUTPUT );
+
+  public:
+
+    inline std::string documentation() const override final
+    {
+      return R"EOF(
+Renumbers every (non-ghost, locally owned) particle's id so that ids form a
+dense, contiguous range [0, N) across the whole simulation (N = total number
+of particles, summed over all MPI ranks), with no gaps.
+
+This is typically needed after operators that remove particles (such as
+'remove_particles'), which leave holes in the id numbering.
+
+Numbering is fully deterministic: particles are numbered in increasing cell
+index order within a rank, and ranks are ordered by MPI rank (via
+MPI_Exscan), so re-running this operator on an unchanged grid always
+produces the same ids, regardless of the number of OpenMP threads used.
+
+WARNING: this reassigns particle identity. Do not use it if anything else
+in the simulation still refers to the previous ids (e.g. bonded/molecular
+topology tables, external post-processing keyed by id, or dump files meant
+to be diffed against a previous state by id). Typically used once right
+after 'remove_particles', before any such id-dependent data is built.
+
+Example:
+  - remove_particles:
+      region: CAVITY
+      fraction: 0.1
+  - compact_particle_ids
+)EOF";
+    }
+
+    inline void execute() override final
+    {
+      auto cells = grid->cells();
+      const IJK dims = grid->dimension();
+      const ssize_t gl = grid->ghost_layers();
+      const IJK gstart { gl, gl, gl };
+      const IJK gend = dims - IJK{ gl, gl, gl };
+      const IJK gdims = gend - gstart;
+      const size_t n_cells = grid->number_of_cells();
+
+      // per-cell particle counts, indexed by linear cell index so that
+      // numbering order only depends on the (fixed, deterministic) grid
+      // layout, never on thread scheduling.
+      std::vector<uint64_t> cell_offset( n_cells, 0 );
+
+#     pragma omp parallel
+      {
+        GRID_OMP_FOR_BEGIN(gdims,_,loc, schedule(dynamic) )
+        {
+          const size_t cell_i = grid_ijk_to_index( dims, loc + gstart );
+          cell_offset[cell_i] = cells[cell_i].size();
+        }
+        GRID_OMP_FOR_END
+      }
+
+      // sequential exclusive prefix sum over cells (one entry per cell,
+      // negligible cost compared to the per-particle work below)
+      uint64_t local_n_particles = 0;
+      for(size_t i=0;i<n_cells;i++)
+      {
+        const uint64_t c = cell_offset[i];
+        cell_offset[i] = local_n_particles;
+        local_n_particles += c;
+      }
+
+      uint64_t rank_id_start = 0;
+      MPI_Exscan( &local_n_particles, &rank_id_start, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, *mpi );
+      // (MPI_Exscan leaves the result undefined on rank 0; rank_id_start
+      // was pre-initialized to 0, which is exactly what we want there)
+
+#     pragma omp parallel
+      {
+        GRID_OMP_FOR_BEGIN(gdims,_,loc, schedule(dynamic) )
+        {
+          const size_t cell_i = grid_ijk_to_index( dims, loc + gstart );
+          const size_t np = cells[cell_i].size();
+          uint64_t next_id = rank_id_start + cell_offset[cell_i];
+          for(size_t p=0;p<np;p++)
+          {
+            cells[cell_i][field::id][p] = next_id++;
+          }
+        }
+        GRID_OMP_FOR_END
+      }
+
+      uint64_t global_n_particles = 0;
+      MPI_Allreduce( &local_n_particles, &global_n_particles, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, *mpi );
+
+      ldbg << "compact_particle_ids: renumbered "<<global_n_particles<<" particles into [0,"<<global_n_particles<<")"<<std::endl;
+    }
+
+  };
+
+  template<class GridT> using CompactParticleIdsTmpl = CompactParticleIds<GridT>;
+
+  // === register factories ===
+  ONIKA_AUTORUN_INIT(compact_particle_ids)
+  {
+    OperatorNodeFactory::instance()->register_factory( "compact_particle_ids", make_grid_variant_operator< CompactParticleIdsTmpl > );
+  }
+
+}

--- a/src/grid_cell_particles/include/exanb/grid_cell_particles/particle_random_selection.h
+++ b/src/grid_cell_particles/include/exanb/grid_cell_particles/particle_random_selection.h
@@ -1,0 +1,168 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+#pragma once
+
+#include <onika/cuda/cuda.h>
+#include <cstdint>
+#include <cmath>
+#include <mpi.h>
+
+namespace exanb
+{
+
+  // ---------------------------------------------------------------------
+  // splitmix64 : small, fast, well distributed 64 bit integer hash.
+  // Used to turn (particle_id , seed) into a reproducible pseudo-random
+  // value, independent of particle ordering, MPI rank count or thread
+  // scheduling. Same id + seed always yields the same key, on CPU or GPU.
+  // ---------------------------------------------------------------------
+  ONIKA_HOST_DEVICE_FUNC inline uint64_t splitmix64( uint64_t x )
+  {
+    x += 0x9E3779B97F4A7C15ULL;
+    uint64_t z = x;
+    z = ( z ^ ( z >> 30 ) ) * 0xBF58476D1CE4E5B9ULL;
+    z = ( z ^ ( z >> 27 ) ) * 0x94D049BB133111EBULL;
+    return z ^ ( z >> 31 );
+  }
+
+  // deterministic pseudo-random key in [0,1) for a given particle id and seed
+  ONIKA_HOST_DEVICE_FUNC inline double particle_random_key( uint64_t id, uint64_t seed )
+  {
+    const uint64_t h = splitmix64( id ^ splitmix64( seed ) );
+    // keep the 53 most significant bits -> uniform double in [0,1)
+    return double( h >> 11 ) * ( 1.0 / 9007199254740992.0 /* 2^53 */ );
+  }
+
+  // ---------------------------------------------------------------------
+  // Describes how many particles (among those passing some spatial /
+  // logical filter) must be selected :
+  //  - ALL      : every eligible particle is selected (plain region selection)
+  //  - FRACTION : each eligible particle is selected independently with
+  //               probability = fraction. Cheap (single pass, no extra
+  //               communication), but the resulting count is only exact
+  //               in expectation.
+  //  - COUNT    : exactly (up to hash collisions, i.e. for all practical
+  //               purposes exactly) 'count' particles are selected globally,
+  //               across all MPI ranks, chosen uniformly at random among
+  //               eligible particles.
+  // ---------------------------------------------------------------------
+  struct ParticleSelectionCount
+  {
+    enum Mode { ALL = 0, FRACTION = 1, COUNT = 2 };
+    Mode mode = ALL;
+    double fraction = 1.0;
+    uint64_t count = 0;
+    uint64_t seed = 0;
+  };
+
+  struct ParticleSelectionThreshold
+  {
+    double tau = 1.0;              // select a particle if particle_random_key(id,seed) < tau
+    uint64_t global_eligible = 0;  // total nb of particles passing the spatial/logical filter, all ranks
+    uint64_t global_target = 0;    // nb of particles the selection is aiming for, all ranks
+  };
+
+  // Computes the selection threshold tau such that, among particles passing
+  // the caller's filter, testing (particle_random_key(id,seed) < tau) selects
+  // the number of particles requested by 'sel', globally across all ranks.
+  //
+  // The caller provides two local (rank-only) callbacks :
+  //   count_eligible()      -> nb of local particles passing the spatial/logical filter
+  //   count_below(tau)      -> nb of local eligible particles whose key < tau
+  //
+  // For FRACTION and ALL modes this only costs one MPI_Allreduce (to know
+  // how many particles are eligible in total). For COUNT mode, an extra
+  // bisection search on tau is run (each iteration costs one MPI_Allreduce
+  // of a local linear scan over already-filtered particles) until the global
+  // selected count matches the target exactly, or double precision is
+  // exhausted (~50 iterations, negligible compared to a typical particle count).
+  template<class CountEligibleFunc, class CountBelowThresholdFunc>
+  inline ParticleSelectionThreshold compute_particle_selection_threshold(
+        MPI_Comm comm,
+        const ParticleSelectionCount& sel,
+        CountEligibleFunc count_eligible,
+        CountBelowThresholdFunc count_below )
+  {
+    ParticleSelectionThreshold result;
+
+    const uint64_t local_eligible = count_eligible();
+    uint64_t global_eligible = 0;
+    MPI_Allreduce( (void*) &local_eligible, (void*) &global_eligible, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, comm );
+    result.global_eligible = global_eligible;
+
+    if( sel.mode == ParticleSelectionCount::ALL || global_eligible == 0 )
+    {
+      result.tau = 1.0;
+      result.global_target = global_eligible;
+      return result;
+    }
+
+    uint64_t target = 0;
+    if( sel.mode == ParticleSelectionCount::FRACTION )
+    {
+      const double f = sel.fraction < 0.0 ? 0.0 : ( sel.fraction > 1.0 ? 1.0 : sel.fraction );
+      target = static_cast<uint64_t>( std::llround( f * double(global_eligible) ) );
+    }
+    else // COUNT
+    {
+      target = sel.count;
+    }
+
+    if( target >= global_eligible )
+    {
+      result.tau = 1.0;
+      result.global_target = global_eligible;
+      return result;
+    }
+    if( target == 0 )
+    {
+      result.tau = 0.0;
+      result.global_target = 0;
+      return result;
+    }
+    result.global_target = target;
+
+    if( sel.mode == ParticleSelectionCount::FRACTION )
+    {
+      // single pass Bernoulli trial : expected count is exact, actual
+      // count may fluctuate slightly. No need for the bisection search.
+      result.tau = double(target) / double(global_eligible);
+      return result;
+    }
+
+    // COUNT mode : bisection search for the exact global count.
+    double lo = 0.0, hi = 1.0;
+    double tau = double(target) / double(global_eligible); // good initial guess
+    for( int it=0 ; it<64 ; it++ )
+    {
+      const uint64_t local_below = count_below( tau );
+      uint64_t global_below = 0;
+      MPI_Allreduce( (void*) &local_below, (void*) &global_below, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, comm );
+      if( global_below == target ) { lo = hi = tau; break; }
+      else if( global_below < target ) { lo = tau; }
+      else { hi = tau; }
+      const double next_tau = 0.5 * ( lo + hi );
+      if( next_tau == tau ) break; // double precision exhausted
+      tau = next_tau;
+    }
+    result.tau = tau;
+    return result;
+  }
+
+}

--- a/src/grid_cell_particles/remove_close_particles.cpp
+++ b/src/grid_cell_particles/remove_close_particles.cpp
@@ -1,0 +1,214 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+#include <onika/scg/operator.h>
+#include <onika/scg/operator_slot.h>
+#include <onika/scg/operator_factory.h>
+#include <onika/log.h>
+
+#include <exanb/core/grid.h>
+#include <exanb/core/make_grid_variant_operator.h>
+#include <exanb/core/parallel_grid_algorithm.h>
+
+#include <exanb/particle_neighbors/chunk_neighbors.h>
+#include <exanb/particle_neighbors/chunk_neighbors_iterator.h>
+
+#include <mpi.h>
+#include <atomic>
+#include <vector>
+#include <cstdint>
+
+namespace exanb
+{
+
+  template<class GridT, class = AssertGridHasFields<GridT, field::_id> >
+  class RemoveCloseParticles : public OperatorNode
+  {
+    ADD_SLOT( MPI_Comm           , mpi             , INPUT , MPI_COMM_WORLD );
+    ADD_SLOT( GridT              , grid            , INPUT_OUTPUT );
+    ADD_SLOT( GridChunkNeighbors , chunk_neighbors , INPUT , GridChunkNeighbors{} );
+    ADD_SLOT( double             , distance        , INPUT , REQUIRED , DocString{"Distance threshold. Whenever two particles are closer than this, the one with the higher particle id is removed."} );
+
+  public:
+
+    inline std::string documentation() const override final
+    {
+      return R"EOF(
+Deletes particles that are closer to another particle than a given threshold distance.
+
+For every too-close pair, the particle with the higher id is the one removed.
+This tie-break is symmetric and needs no cross-rank coordination: each rank
+only ever deletes particles it owns, based on its own neighbor list (which
+includes ghost-mirrored particles owned by other ranks). Only non-ghost cells
+are affected (ghost particles are rebuilt by the next ghost update anyway).
+Particle ids are NOT renumbered; chain with 'compact_particle_ids' afterwards
+if a dense [0,N) numbering is required.
+
+Requires 'chunk_neighbors' to have been built earlier in the pipeline with a
+search distance greater than or equal to 'distance', and NOT in
+half_symmetric mode (the exaNBody default), since every particle needs to
+see its full neighbor list to decide on its own whether it must be removed.
+
+A single pass may not fully resolve chains of mutually close particles
+(A close to B close to C): re-run the operator (or loop it) until 'removed'
+converges to 0 if that matters for your use case.
+
+Usage example:
+
+# delete particles that are closer than 0.5 to another particle
+  - remove_close_particles:
+      distance: 0.5
+)EOF";
+    }
+
+    inline void execute() override final
+    {
+      // no early return on zero local particles here: every rank must reach the
+      // MPI_Allreduce below regardless, or ranks that locally have no particles
+      // would desync the collective call from ranks that do.
+      if( chunk_neighbors->number_of_cells() != grid->number_of_cells() )
+      {
+        fatal_error() << "remove_close_particles: chunk_neighbors is not built (or stale) for this grid."
+                       << " Place this operator after neighbor lists have been computed"
+                       << " (e.g. after 'init_particles' / inside '+first_iteration')." << std::endl;
+      }
+
+      auto cells = grid->cells();
+      using CellT = std::remove_cv_t< std::remove_reference_t< decltype(cells[0]) > >;
+      const IJK dims = grid->dimension();
+      const ssize_t gl = grid->ghost_layers();
+      const IJK gstart { gl, gl, gl };
+      const IJK gend = dims - IJK{ gl, gl, gl };
+      const IJK gdims = gend - gstart;
+      const auto & cell_allocator = grid->cell_allocator();
+
+      const double threshold2 = (*distance) * (*distance);
+      std::vector< std::vector<uint8_t> > remove_flag( grid->number_of_cells() );
+
+      ChunkParticleNeighborsIterator<CellT> chunk_nbh_it_in = { grid->cells(), chunk_neighbors->data(), dims, chunk_neighbors->m_chunk_size };
+
+      // --- pass 1 : read-only decision pass ---
+      // A particle marks itself if it has a closer-than-threshold neighbor with a
+      // smaller id. Neighbor lists are full (not half_symmetric), so every particle
+      // sees this on its own: no need to know the other side's decision. This makes
+      // it safe to run in parallel over cells while other threads concurrently read
+      // (but never write) neighboring cells' particle data.
+#     pragma omp parallel
+      {
+        auto chunk_nbh_it = chunk_nbh_it_in;
+        GRID_OMP_FOR_BEGIN(gdims,_,loc, schedule(dynamic) )
+        {
+          const size_t cell_i = grid_ijk_to_index( dims, loc + gstart );
+          const size_t np = cells[cell_i].size();
+          remove_flag[cell_i].assign( np, 0 );
+          if( np > 0 )
+          {
+            const double* __restrict__ rx_a = cells[cell_i][field::rx];
+            const double* __restrict__ ry_a = cells[cell_i][field::ry];
+            const double* __restrict__ rz_a = cells[cell_i][field::rz];
+            const uint64_t* __restrict__ id_a = cells[cell_i][field::id];
+
+            chunk_nbh_it.start_cell( cell_i, np );
+            for(size_t p_a=0;p_a<np;p_a++)
+            {
+              chunk_nbh_it.start_particle( p_a );
+              bool remove = false;
+              while( ! chunk_nbh_it.end() )
+              {
+                size_t cell_b=0, p_b=0;
+                chunk_nbh_it.get_nbh( cell_b, p_b );
+                const uint64_t id_b = cells[cell_b][field::id][p_b];
+                if( id_b < id_a[p_a] )
+                {
+                  const double dx = cells[cell_b][field::rx][p_b] - rx_a[p_a];
+                  const double dy = cells[cell_b][field::ry][p_b] - ry_a[p_a];
+                  const double dz = cells[cell_b][field::rz][p_b] - rz_a[p_a];
+                  if( dx*dx + dy*dy + dz*dz < threshold2 ) { remove = true; }
+                }
+                chunk_nbh_it.next();
+              }
+              remove_flag[cell_i][p_a] = remove ? 1 : 0;
+            }
+          }
+        }
+        GRID_OMP_FOR_END
+      }
+
+      // --- pass 2 : in-place compaction (swap-with-tail, same scheme as remove_particles) ---
+      std::atomic<uint64_t> n_removed = 0;
+#     pragma omp parallel
+      {
+        std::vector<int32_t> particle_pack;
+        GRID_OMP_FOR_BEGIN(gdims,_,loc, schedule(dynamic) )
+        {
+          const size_t cell_i = grid_ijk_to_index( dims, loc + gstart );
+          int32_t n = static_cast<int32_t>( cells[cell_i].size() );
+          if( n > 0 )
+          {
+            particle_pack.resize( n );
+            for(int32_t j=0;j<n;j++) { particle_pack[j] = j; }
+
+            int32_t n_out = 0;
+            for(int32_t j=0;j<n;j++)
+            {
+              if( remove_flag[cell_i][j] ) { particle_pack[j] = -1; ++n_out; }
+            }
+
+            if( n_out > 0 )
+            {
+              for(int32_t j=n-1;j>=0;j--)
+              {
+                if( particle_pack[j] == -1 )
+                {
+                  if( j < n-1 ) { particle_pack[j] = particle_pack[n-1]; }
+                  --n;
+                }
+              }
+              for(int32_t j=0;j<n;j++)
+              {
+                if( j != particle_pack[j] ) { cells[cell_i].set_tuple( j , cells[cell_i][ particle_pack[j] ] ); }
+              }
+              cells[cell_i].resize( n, cell_allocator );
+              n_removed.fetch_add( static_cast<uint64_t>(n_out), std::memory_order_relaxed );
+            }
+          }
+        }
+        GRID_OMP_FOR_END
+      }
+
+      grid->rebuild_particle_offsets();
+
+      unsigned long long local_removed = n_removed.load();
+      unsigned long long global_removed = 0;
+      MPI_Allreduce( &local_removed, &global_removed, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, *mpi );
+
+      ldbg << "remove_close_particles: distance="<<(*distance)<<" removed="<<global_removed<<std::endl;
+    }
+
+  };
+
+  template<class GridT> using RemoveCloseParticlesTmpl = RemoveCloseParticles<GridT>;
+
+  // === register factories ===
+  ONIKA_AUTORUN_INIT(remove_close_particles)
+  {
+    OperatorNodeFactory::instance()->register_factory( "remove_close_particles", make_grid_variant_operator< RemoveCloseParticlesTmpl > );
+  }
+
+}

--- a/src/grid_cell_particles/remove_close_particles.cpp
+++ b/src/grid_cell_particles/remove_close_particles.cpp
@@ -28,6 +28,7 @@ under the License.
 
 #include <exanb/particle_neighbors/chunk_neighbors.h>
 #include <exanb/particle_neighbors/chunk_neighbors_iterator.h>
+#include <exanb/grid_cell_particles/particle_random_selection.h>
 
 #include <mpi.h>
 #include <atomic>
@@ -43,7 +44,8 @@ namespace exanb
     ADD_SLOT( MPI_Comm           , mpi             , INPUT , MPI_COMM_WORLD );
     ADD_SLOT( GridT              , grid            , INPUT_OUTPUT );
     ADD_SLOT( GridChunkNeighbors , chunk_neighbors , INPUT , GridChunkNeighbors{} );
-    ADD_SLOT( double             , distance        , INPUT , REQUIRED , DocString{"Distance threshold. Whenever two particles are closer than this, the one with the higher particle id is removed."} );
+    ADD_SLOT( double             , distance        , INPUT , REQUIRED , DocString{"Distance threshold. Whenever two particles are closer than this, one of the two is removed."} );
+    ADD_SLOT( uint64_t           , seed            , INPUT , 0 , DocString{"Seed for the random tie-break between too-close particles. Same seed always yields the same removal set."} );
 
   public:
 
@@ -52,11 +54,17 @@ namespace exanb
       return R"EOF(
 Deletes particles that are closer to another particle than a given threshold distance.
 
-For every too-close pair, the particle with the higher id is the one removed.
-This tie-break is symmetric and needs no cross-rank coordination: each rank
-only ever deletes particles it owns, based on its own neighbor list (which
-includes ghost-mirrored particles owned by other ranks). Only non-ghost cells
-are affected (ghost particles are rebuilt by the next ghost update anyway).
+For every too-close pair, the one removed is picked with a random key derived
+from the particle id and 'seed' (splitmix64-based, see particle_random_key):
+the particle with the higher key is removed. Randomizing the key (instead of
+using the id directly) avoids pathological removal patterns correlated with
+id ordering (e.g. ids assigned in lattice/generation order). The tie-break is
+still symmetric and needs no cross-rank coordination: each rank only ever
+deletes particles it owns, based on its own neighbor list (which includes
+ghost-mirrored particles owned by other ranks) and the same deterministic key
+for a given id, so both sides of a pair agree without communication. Only
+non-ghost cells are affected (ghost particles are rebuilt by the next ghost
+update anyway).
 Particle ids are NOT renumbered; chain with 'compact_particle_ids' afterwards
 if a dense [0,N) numbering is required.
 
@@ -74,6 +82,11 @@ Usage example:
 # delete particles that are closer than 0.5 to another particle
   - remove_close_particles:
       distance: 0.5
+
+# same, with an explicit seed so the removal set is reproducible run to run
+  - remove_close_particles:
+      distance: 0.5
+      seed: 42
 )EOF";
     }
 
@@ -99,16 +112,17 @@ Usage example:
       const auto & cell_allocator = grid->cell_allocator();
 
       const double threshold2 = (*distance) * (*distance);
+      const uint64_t rng_seed = *seed;
       std::vector< std::vector<uint8_t> > remove_flag( grid->number_of_cells() );
 
       ChunkParticleNeighborsIterator<CellT> chunk_nbh_it_in = { grid->cells(), chunk_neighbors->data(), dims, chunk_neighbors->m_chunk_size };
 
       // --- pass 1 : read-only decision pass ---
       // A particle marks itself if it has a closer-than-threshold neighbor with a
-      // smaller id. Neighbor lists are full (not half_symmetric), so every particle
-      // sees this on its own: no need to know the other side's decision. This makes
-      // it safe to run in parallel over cells while other threads concurrently read
-      // (but never write) neighboring cells' particle data.
+      // smaller random key. Neighbor lists are full (not half_symmetric), so every
+      // particle sees this on its own: no need to know the other side's decision.
+      // This makes it safe to run in parallel over cells while other threads
+      // concurrently read (but never write) neighboring cells' particle data.
 #     pragma omp parallel
       {
         auto chunk_nbh_it = chunk_nbh_it_in;
@@ -127,6 +141,7 @@ Usage example:
             chunk_nbh_it.start_cell( cell_i, np );
             for(size_t p_a=0;p_a<np;p_a++)
             {
+              const double key_a = particle_random_key( id_a[p_a], rng_seed );
               chunk_nbh_it.start_particle( p_a );
               bool remove = false;
               while( ! chunk_nbh_it.end() )
@@ -134,7 +149,7 @@ Usage example:
                 size_t cell_b=0, p_b=0;
                 chunk_nbh_it.get_nbh( cell_b, p_b );
                 const uint64_t id_b = cells[cell_b][field::id][p_b];
-                if( id_b < id_a[p_a] )
+                if( particle_random_key( id_b, rng_seed ) < key_a )
                 {
                   const double dx = cells[cell_b][field::rx][p_b] - rx_a[p_a];
                   const double dy = cells[cell_b][field::ry][p_b] - ry_a[p_a];

--- a/src/grid_cell_particles/remove_particles.cpp
+++ b/src/grid_cell_particles/remove_particles.cpp
@@ -1,0 +1,250 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+#include <onika/scg/operator.h>
+#include <onika/scg/operator_slot.h>
+#include <onika/scg/operator_factory.h>
+#include <onika/log.h>
+
+#include <exanb/core/grid.h>
+#include <exanb/core/domain.h>
+#include <exanb/core/xform.h>
+#include <exanb/core/make_grid_variant_operator.h>
+#include <exanb/core/parallel_grid_algorithm.h>
+
+#include <exanb/grid_cell_particles/particle_region.h>
+#include <exanb/grid_cell_particles/particle_localized_filter.h>
+#include <exanb/grid_cell_particles/particle_random_selection.h>
+
+#include <mpi.h>
+#include <atomic>
+#include <vector>
+#include <cstdint>
+
+namespace exanb
+{
+
+  template<class GridT, class = AssertGridHasFields<GridT, field::_id> >
+  class RemoveParticles : public OperatorNode
+  {
+    ADD_SLOT( MPI_Comm          , mpi              , INPUT , MPI_COMM_WORLD );
+    ADD_SLOT( GridT             , grid             , INPUT_OUTPUT );
+    ADD_SLOT( Domain            , domain           , INPUT );
+
+    ADD_SLOT( ParticleRegions   , particle_regions , INPUT , OPTIONAL );
+    ADD_SLOT( ParticleRegionCSG , region           , INPUT , OPTIONAL , DocString{"Restricts candidate particles to this region (boolean expression over named particle_regions). If absent, the whole local domain is considered."} );
+
+    ADD_SLOT( double            , fraction         , INPUT , OPTIONAL , DocString{"Fraction (0..1) of eligible particles to delete, drawn at random. Mutually exclusive with 'count'."} );
+    ADD_SLOT( long               , count            , INPUT , OPTIONAL , DocString{"Exact number of eligible particles to delete, drawn at random, globally across all MPI ranks. Mutually exclusive with 'fraction'."} );
+    ADD_SLOT( long               , seed             , INPUT , 0 , DocString{"Seed for the deterministic random selection. Same seed + same particle ids => same selection, regardless of rank/thread count."} );
+
+  public:
+
+    inline std::string documentation() const override final
+    {
+      return R"EOF(
+Deletes a subset of particles from the grid.
+
+Candidate ("eligible") particles can optionally be restricted to a spatial
+region via 'region' (a boolean expression over named 'particle_regions').
+Among the eligible particles, the ones actually deleted are chosen either:
+  - all of them                     (neither 'fraction' nor 'count' given)
+  - a random fraction of them        ('fraction': 0..1, expected count only)
+  - an exact random number of them   ('count': exact, global across ranks)
+
+Selection is deterministic given 'seed' and particle ids. Only non-ghost
+cells are affected (ghost particles are rebuilt by the next ghost update
+anyway). Particle ids are NOT renumbered by this operator: deleting
+particles leaves holes in the id numbering. Chain with 'compact_particle_ids'
+afterwards if a dense [0,N) numbering is required.
+
+Usage examples:
+
+# delete every particle inside a region
+  - remove_particles:
+      region: CAVITY
+
+# delete a random 5% of the particles anywhere in the domain
+  - remove_particles:
+      fraction: 0.05
+      seed: 7
+
+# delete exactly 1000 random particles inside a region
+  - remove_particles:
+      region: CAVITY
+      count: 1000
+      seed: 7
+)EOF";
+    }
+
+    inline void execute() override final
+    {
+      if( fraction.has_value() && count.has_value() )
+      {
+        fatal_error() << "remove_particles: 'fraction' and 'count' are mutually exclusive" << std::endl;
+      }
+
+      PartcileLocalizedFilter<GridT,LinearXForm> particle_filter = { *grid, { domain->xform() } };
+      particle_filter.initialize_from_optional_parameters( particle_regions.get_pointer(), region.get_pointer() );
+
+      ParticleSelectionCount sel;
+      sel.seed = static_cast<uint64_t>( *seed );
+      if( fraction.has_value() )      { sel.mode = ParticleSelectionCount::FRACTION; sel.fraction = *fraction; }
+      else if( count.has_value() )    { sel.mode = ParticleSelectionCount::COUNT;    sel.count    = static_cast<uint64_t>( *count ); }
+      else                            { sel.mode = ParticleSelectionCount::ALL; }
+      const uint64_t seedv = sel.seed;
+
+      auto cells = grid->cells();
+      const IJK dims = grid->dimension();
+      const ssize_t gl = grid->ghost_layers();
+      const IJK gstart { gl, gl, gl };
+      const IJK gend = dims - IJK{ gl, gl, gl };
+      const IJK gdims = gend - gstart;
+      const auto & cell_allocator = grid->cell_allocator();
+
+      // only non-ghost cells are ever considered: ghost cells mirror another
+      // rank's owned particles and are fully rebuilt by the next ghost update.
+      auto is_eligible = [&]( size_t cell_i, size_t p ) -> bool
+      {
+        const Vec3d r = { cells[cell_i][field::rx][p], cells[cell_i][field::ry][p], cells[cell_i][field::rz][p] };
+        const uint64_t id = cells[cell_i][field::id][p];
+        return particle_filter( r, id );
+      };
+
+      auto count_eligible = [&]() -> uint64_t
+      {
+        std::atomic<uint64_t> n = 0;
+#       pragma omp parallel
+        {
+          GRID_OMP_FOR_BEGIN(gdims,_,loc, schedule(dynamic) )
+          {
+            const size_t cell_i = grid_ijk_to_index( dims, loc + gstart );
+            const size_t np = cells[cell_i].size();
+            uint64_t local_n = 0;
+            for(size_t p=0;p<np;p++) { if( is_eligible(cell_i,p) ) ++local_n; }
+            n.fetch_add( local_n, std::memory_order_relaxed );
+          }
+          GRID_OMP_FOR_END
+        }
+        return n.load();
+      };
+
+      auto count_below = [&]( double tau ) -> uint64_t
+      {
+        std::atomic<uint64_t> n = 0;
+#       pragma omp parallel
+        {
+          GRID_OMP_FOR_BEGIN(gdims,_,loc, schedule(dynamic) )
+          {
+            const size_t cell_i = grid_ijk_to_index( dims, loc + gstart );
+            const size_t np = cells[cell_i].size();
+            uint64_t local_n = 0;
+            for(size_t p=0;p<np;p++)
+            {
+              if( is_eligible(cell_i,p) )
+              {
+                const uint64_t id = cells[cell_i][field::id][p];
+                if( particle_random_key(id,seedv) < tau ) ++local_n;
+              }
+            }
+            n.fetch_add( local_n, std::memory_order_relaxed );
+          }
+          GRID_OMP_FOR_END
+        }
+        return n.load();
+      };
+
+      const auto th = compute_particle_selection_threshold( *mpi, sel, count_eligible, count_below );
+
+      // --- selection + in-place compaction pass ---
+      // For each cell: mark selected (to-delete) particle slots with -1 in a
+      // "particle_pack" permutation array, then, scanning from the tail down,
+      // fill each hole with the last still-valid slot (this is the same
+      // swap-with-tail compaction used when particles leave a cell in
+      // move_particles_across_cells.h). Finally shrink the cell to its new size.
+      std::atomic<uint64_t> n_removed = 0;
+#     pragma omp parallel
+      {
+        std::vector<int32_t> particle_pack;
+        GRID_OMP_FOR_BEGIN(gdims,_,loc, schedule(dynamic) )
+        {
+          const size_t cell_i = grid_ijk_to_index( dims, loc + gstart );
+          int32_t n = static_cast<int32_t>( cells[cell_i].size() );
+          if( n > 0 )
+          {
+            particle_pack.resize( n );
+            for(int32_t j=0;j<n;j++) { particle_pack[j] = j; }
+
+            int32_t n_out = 0;
+            for(int32_t j=0;j<n;j++)
+            {
+              if( is_eligible(cell_i,j) )
+              {
+                const uint64_t id = cells[cell_i][field::id][j];
+                if( particle_random_key(id,seedv) < th.tau )
+                {
+                  particle_pack[j] = -1;
+                  ++n_out;
+                }
+              }
+            }
+
+            if( n_out > 0 )
+            {
+              for(int32_t j=n-1;j>=0;j--)
+              {
+                if( particle_pack[j] == -1 )
+                {
+                  if( j < n-1 ) { particle_pack[j] = particle_pack[n-1]; }
+                  --n;
+                }
+              }
+              for(int32_t j=0;j<n;j++)
+              {
+                if( j != particle_pack[j] ) { cells[cell_i].set_tuple( j , cells[cell_i][ particle_pack[j] ] ); }
+              }
+              cells[cell_i].resize( n, cell_allocator );
+              n_removed.fetch_add( static_cast<uint64_t>(n_out), std::memory_order_relaxed );
+            }
+          }
+        }
+        GRID_OMP_FOR_END
+      }
+
+      grid->rebuild_particle_offsets();
+
+      unsigned long long local_removed = n_removed.load();
+      unsigned long long global_removed = 0;
+      MPI_Allreduce( &local_removed, &global_removed, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, *mpi );
+
+      ldbg << "remove_particles: eligible="<<th.global_eligible<<" target="<<th.global_target
+           <<" removed="<<global_removed<<std::endl;
+    }
+
+  };
+
+  template<class GridT> using RemoveParticlesTmpl = RemoveParticles<GridT>;
+
+  // === register factories ===
+  ONIKA_AUTORUN_INIT(remove_particles)
+  {
+    OperatorNodeFactory::instance()->register_factory( "remove_particles", make_grid_variant_operator< RemoveParticlesTmpl > );
+  }
+
+}

--- a/src/grid_cell_particles/set_particle_type.cpp
+++ b/src/grid_cell_particles/set_particle_type.cpp
@@ -1,0 +1,232 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+#include <onika/scg/operator.h>
+#include <onika/scg/operator_slot.h>
+#include <onika/scg/operator_factory.h>
+#include <onika/log.h>
+
+#include <exanb/core/grid.h>
+#include <exanb/core/domain.h>
+#include <exanb/core/xform.h>
+#include <exanb/core/make_grid_variant_operator.h>
+#include <exanb/core/parallel_grid_algorithm.h>
+#include <exanb/core/particle_type_id.h>
+
+#include <exanb/grid_cell_particles/particle_region.h>
+#include <exanb/grid_cell_particles/particle_localized_filter.h>
+#include <exanb/grid_cell_particles/particle_random_selection.h>
+
+#include <mpi.h>
+#include <atomic>
+#include <string>
+#include <cstdint>
+
+namespace exanb
+{
+
+  template<class GridT, class = AssertGridHasFields<GridT, field::_id, field::_type> >
+  class SetParticleType : public OperatorNode
+  {
+    ADD_SLOT( MPI_Comm          , mpi               , INPUT , MPI_COMM_WORLD );
+    ADD_SLOT( GridT             , grid              , INPUT_OUTPUT );
+    ADD_SLOT( Domain            , domain            , INPUT );
+
+    ADD_SLOT( ParticleTypeMap   , particle_type_map , INPUT , OPTIONAL , DocString{"Maps type names to internal integer ids. Required in order to resolve 'type' by name."} );
+    ADD_SLOT( std::string       , type              , INPUT , REQUIRED , DocString{"Name of the new particle type assigned to selected particles (looked up in particle_type_map)."} );
+
+    ADD_SLOT( ParticleRegions   , particle_regions  , INPUT , OPTIONAL );
+    ADD_SLOT( ParticleRegionCSG , region            , INPUT_OUTPUT , OPTIONAL , DocString{"Restricts candidate particles to this region (boolean expression over named particle_regions). If absent, the whole local domain is considered."} );
+
+    ADD_SLOT( double            , fraction          , INPUT , OPTIONAL , DocString{"Fraction (0..1) of eligible particles to convert, drawn at random. Mutually exclusive with 'count'."} );
+    ADD_SLOT( long               , count             , INPUT , OPTIONAL , DocString{"Exact number of eligible particles to convert, drawn at random, globally across all MPI ranks. Mutually exclusive with 'fraction'."} );
+    ADD_SLOT( long               , seed              , INPUT , 0 , DocString{"Seed for the deterministic random selection. Same seed + same particle ids => same selection, regardless of rank/thread count."} );
+    ADD_SLOT( bool               , ghost             , INPUT , false , DocString{"If true, ghost cells are processed too (rarely useful: ghosts get overwritten on the next ghost update)."} );
+
+  public:
+
+    inline std::string documentation() const override final
+    {
+      return R"EOF(
+Randomly reassigns the type of a subset of particles.
+
+Candidate ("eligible") particles can optionally be restricted to a spatial
+region via 'region' (a boolean expression over named 'particle_regions').
+Among the eligible particles, the ones actually converted are chosen either:
+  - all of them                     (neither 'fraction' nor 'count' given)
+  - a random fraction of them        ('fraction': 0..1, expected count only)
+  - an exact random number of them   ('count': exact, global across ranks)
+
+Selection is deterministic given 'seed' and particle ids: re-running the
+operator on the same grid with the same seed reproduces the same selection,
+independently of the number of MPI ranks or OpenMP threads.
+
+Usage examples:
+
+# convert every particle inside a region to type B
+  - set_particle_type:
+      region: INCLUSION
+      type: B
+
+# convert ~20% of the particles inside a region to type B
+  - set_particle_type:
+      region: INCLUSION
+      type: B
+      fraction: 0.2
+      seed: 42
+
+# convert exactly 5000 particles anywhere in the domain to type B
+  - set_particle_type:
+      type: B
+      count: 5000
+      seed: 42
+)EOF";
+    }
+
+    inline void execute() override final
+    {
+      if( fraction.has_value() && count.has_value() )
+      {
+        fatal_error() << "set_particle_type: 'fraction' and 'count' are mutually exclusive" << std::endl;
+      }
+      if( ! particle_type_map.has_value() )
+      {
+        fatal_error() << "set_particle_type: particle_type_map is undefined, cannot resolve type name '"<<(*type)<<"'" << std::endl;
+      }
+      const auto it = particle_type_map->find( *type );
+      if( it == particle_type_map->end() )
+      {
+        fatal_error() << "set_particle_type: unknown particle type '"<<(*type)<<"'" << std::endl;
+      }
+      const ParticleTypeInt new_type_id = static_cast<ParticleTypeInt>( it->second );
+
+      PartcileLocalizedFilter<GridT,LinearXForm> particle_filter = { *grid, { domain->xform() } };
+      particle_filter.initialize_from_optional_parameters( particle_regions.get_pointer(), region.get_pointer() );
+
+      ParticleSelectionCount sel;
+      sel.seed = static_cast<uint64_t>( *seed );
+      if( fraction.has_value() )      { sel.mode = ParticleSelectionCount::FRACTION; sel.fraction = *fraction; }
+      else if( count.has_value() )    { sel.mode = ParticleSelectionCount::COUNT;    sel.count    = static_cast<uint64_t>( *count ); }
+      else                            { sel.mode = ParticleSelectionCount::ALL; }
+      const uint64_t seedv = sel.seed;
+
+      auto cells = grid->cells();
+      const IJK dims = grid->dimension();
+      ssize_t gl = 0;
+      if( ! *ghost ) { gl = grid->ghost_layers(); }
+      const IJK gstart { gl, gl, gl };
+      const IJK gend = dims - IJK{ gl, gl, gl };
+      const IJK gdims = gend - gstart;
+
+      auto is_eligible = [&]( size_t cell_i, size_t p ) -> bool
+      {
+        const Vec3d r = { cells[cell_i][field::rx][p], cells[cell_i][field::ry][p], cells[cell_i][field::rz][p] };
+        const uint64_t id = cells[cell_i][field::id][p];
+        return particle_filter( r, id );
+      };
+
+      auto count_eligible = [&]() -> uint64_t
+      {
+        std::atomic<uint64_t> n = 0;
+#       pragma omp parallel
+        {
+          GRID_OMP_FOR_BEGIN(gdims,_,loc, schedule(dynamic) )
+          {
+            const size_t cell_i = grid_ijk_to_index( dims, loc + gstart );
+            const size_t np = cells[cell_i].size();
+            uint64_t local_n = 0;
+            for(size_t p=0;p<np;p++) { if( is_eligible(cell_i,p) ) ++local_n; }
+            n.fetch_add( local_n, std::memory_order_relaxed );
+          }
+          GRID_OMP_FOR_END
+        }
+        return n.load();
+      };
+
+      auto count_below = [&]( double tau ) -> uint64_t
+      {
+        std::atomic<uint64_t> n = 0;
+#       pragma omp parallel
+        {
+          GRID_OMP_FOR_BEGIN(gdims,_,loc, schedule(dynamic) )
+          {
+            const size_t cell_i = grid_ijk_to_index( dims, loc + gstart );
+            const size_t np = cells[cell_i].size();
+            uint64_t local_n = 0;
+            for(size_t p=0;p<np;p++)
+            {
+              if( is_eligible(cell_i,p) )
+              {
+                const uint64_t id = cells[cell_i][field::id][p];
+                if( particle_random_key(id,seedv) < tau ) ++local_n;
+              }
+            }
+            n.fetch_add( local_n, std::memory_order_relaxed );
+          }
+          GRID_OMP_FOR_END
+        }
+        return n.load();
+      };
+
+      const auto th = compute_particle_selection_threshold( *mpi, sel, count_eligible, count_below );
+
+      std::atomic<uint64_t> n_converted = 0;
+#     pragma omp parallel
+      {
+        GRID_OMP_FOR_BEGIN(gdims,_,loc, schedule(dynamic) )
+        {
+          const size_t cell_i = grid_ijk_to_index( dims, loc + gstart );
+          const size_t np = cells[cell_i].size();
+          uint64_t local_n = 0;
+          for(size_t p=0;p<np;p++)
+          {
+            if( is_eligible(cell_i,p) )
+            {
+              const uint64_t id = cells[cell_i][field::id][p];
+              if( particle_random_key(id,seedv) < th.tau )
+              {
+                cells[cell_i][field::type][p] = new_type_id;
+                ++local_n;
+              }
+            }
+          }
+          n_converted.fetch_add( local_n, std::memory_order_relaxed );
+        }
+        GRID_OMP_FOR_END
+      }
+
+      unsigned long long local_converted = n_converted.load();
+      unsigned long long global_converted = 0;
+      MPI_Allreduce( &local_converted, &global_converted, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, *mpi );
+
+      ldbg << "set_particle_type: eligible="<<th.global_eligible<<" target="<<th.global_target
+           <<" converted="<<global_converted<<" -> type '"<<(*type)<<"' (id="<<int(new_type_id)<<")"<<std::endl;
+    }
+
+  };
+
+  template<class GridT> using SetParticleTypeTmpl = SetParticleType<GridT>;
+
+  // === register factories ===
+  ONIKA_AUTORUN_INIT(set_particle_type)
+  {
+    OperatorNodeFactory::instance()->register_factory( "set_particle_type", make_grid_variant_operator< SetParticleTypeTmpl > );
+  }
+
+}

--- a/src/grid_cell_particles/set_particle_type.cpp
+++ b/src/grid_cell_particles/set_particle_type.cpp
@@ -55,9 +55,9 @@ namespace exanb
     ADD_SLOT( ParticleRegionCSG , region            , INPUT_OUTPUT , OPTIONAL , DocString{"Restricts candidate particles to this region (boolean expression over named particle_regions). If absent, the whole local domain is considered."} );
 
     ADD_SLOT( double            , fraction          , INPUT , OPTIONAL , DocString{"Fraction (0..1) of eligible particles to convert, drawn at random. Mutually exclusive with 'count'."} );
-    ADD_SLOT( long               , count             , INPUT , OPTIONAL , DocString{"Exact number of eligible particles to convert, drawn at random, globally across all MPI ranks. Mutually exclusive with 'fraction'."} );
-    ADD_SLOT( long               , seed              , INPUT , 0 , DocString{"Seed for the deterministic random selection. Same seed + same particle ids => same selection, regardless of rank/thread count."} );
-    ADD_SLOT( bool               , ghost             , INPUT , false , DocString{"If true, ghost cells are processed too (rarely useful: ghosts get overwritten on the next ghost update)."} );
+    ADD_SLOT( long              , count             , INPUT , OPTIONAL , DocString{"Exact number of eligible particles to convert, drawn at random, globally across all MPI ranks. Mutually exclusive with 'fraction'."} );
+    ADD_SLOT( long              , seed              , INPUT , 0 , DocString{"Seed for the deterministic random selection. Same seed + same particle ids => same selection, regardless of rank/thread count."} );
+    ADD_SLOT( bool              , ghost             , INPUT , false , DocString{"If true, ghost cells are processed too (rarely useful: ghosts get overwritten on the next ghost update)."} );
 
   public:
 

--- a/src/grid_cell_particles/set_particle_type.cpp
+++ b/src/grid_cell_particles/set_particle_type.cpp
@@ -52,7 +52,7 @@ namespace exanb
     ADD_SLOT( std::string       , type              , INPUT , REQUIRED , DocString{"Name of the new particle type assigned to selected particles (looked up in particle_type_map)."} );
 
     ADD_SLOT( ParticleRegions   , particle_regions  , INPUT , OPTIONAL );
-    ADD_SLOT( ParticleRegionCSG , region            , INPUT_OUTPUT , OPTIONAL , DocString{"Restricts candidate particles to this region (boolean expression over named particle_regions). If absent, the whole local domain is considered."} );
+    ADD_SLOT( ParticleRegionCSG , region            , INPUT , OPTIONAL , DocString{"Restricts candidate particles to this region (boolean expression over named particle_regions). If absent, the whole local domain is considered."} );
 
     ADD_SLOT( double            , fraction          , INPUT , OPTIONAL , DocString{"Fraction (0..1) of eligible particles to convert, drawn at random. Mutually exclusive with 'count'."} );
     ADD_SLOT( long              , count             , INPUT , OPTIONAL , DocString{"Exact number of eligible particles to convert, drawn at random, globally across all MPI ranks. Mutually exclusive with 'fraction'."} );


### PR DESCRIPTION
Randomly or fully deletes a subset of particles from the grid inside a named region or everywhere with **remove_particles**.
Also added the **compact_particle_ids** operator to generate a dense numbering of particle ids.

See example and description below:
<img width="400" height="400" alt="remove_particles_example" src="https://github.com/user-attachments/assets/8275b512-bd7f-485a-81ea-db012622621b" />


Candidate ("eligible") particles can optionally be restricted to a spatial region via 'region' (a boolean expression over named 'particle_regions'). Among the eligible particles, the ones actually deleted are chosen either:
  - all of them                     (neither 'fraction' nor 'count' given)
  - a random fraction of them        ('fraction': 0..1, expected count only)
  - an exact random number of them   ('count': exact, global across ranks)

Selection is deterministic given 'seed' and particle ids. Only non-ghost cells are affected (ghost particles are rebuilt by the next ghost update anyway). Particle ids are NOT renumbered by this operator: deleting particles leaves holes in the id numbering. Chain with 'compact_particle_ids' afterwards if a dense [0,N) numbering is required.

Usage examples:
```yaml
# delete every particle inside a region
  - remove_particles:
      region: CAVITY

# delete a random 5% of the particles anywhere in the domain
  - remove_particles:
      fraction: 0.05
      seed: 7

# delete exactly 1000 random particles inside a region
  - remove_particles:
      region: CAVITY
      count: 1000
      seed: 7
```
Here's a full example that generates the image below:
```yaml
global:
  dt: 1.0e-5 ps
  rcut_max: 4.0 ang
  rcut_inc: 1.0 ang
  simulation_log_frequency: 1
  simulation_end_iteration: 1

compute_force: nop

input_data:
  - domain:
      cell_size: 10.0 ang
      grid_dims: [ 20 , 20 , 2 ]
      bounds: [ [ 0.0 um , 0.0 um , 0.0 um ] , [ 200.0 ang , 200.0 ang , 20.0 ang ] ]
      periodic: [ true , true , true ]
      expandable: false
      xform: [ [ 1 , 0 , 0 ] , [ 0 , 1 , 0 ] , [ 0 , 0 , 1 ] ]
  - init_rcb_grid
  - particle_types:
      particle_type_map: { A: 0 }
  - particle_type_add_properties:
      A: { mass: 30 Da , radius: 1.0 ang , charge: 0 e- }
  - particle_regions:
      - BOX:
          bounds: [ [ 25 ang , 25 ang , -100 ang ] , [ 50 ang , 120 ang , 100 ang ] ]
      - BOX2:
          bounds: [ [ 75 ang , 5 ang , -100 ang ] , [ 180 ang , 35 ang , 100 ang ] ]
      - CYL:
          quadric:
            shape: cylz
            transform:
              - scale: [ 20 ang , 50 ang , 20 ang ]
              - zrot: pi/4
              - translate: [ 120 ang , 130 ang , 0 ang ]
      - CYL2:
          quadric:
            shape: cylz
            transform:
              - scale: [ 30 ang , 30 ang , 20 ang ]
              - translate: [ 0 ang , 200 ang , 0 ang ]
  - lattice:
      structure: SC
      types: [ A ]
      size: [ 2.5 ang , 2.5 ang , 2.5 ang ]
  - gaussian_noise_r:
      sigma: 0.5 ang
      sigma_cut: 0.4 ang
  - remove_particles:
      region: BOX
  - compact_particle_ids
  - remove_particles:
      region: CYL
  - compact_particle_ids
  - remove_particles:
      region: BOX2
      fraction: 0.3
  - compact_particle_ids
  - remove_particles:
      region: CYL2
      count: 500
  - compact_particle_ids
      
final_dump:
  - write_xyz:
      filename: "test_remove_particles.xyz"
      fields: [ id , type , mass ]

simulation: default_simulation
```