### PR TITLE
add the check_value_consistency function in the extra storage plugin

### DIFF
--- a/src/extra_storage/include/exanb/extra_storage/dynamic_data_storage.hpp
+++ b/src/extra_storage/include/exanb/extra_storage/dynamic_data_storage.hpp
@@ -389,6 +389,7 @@ namespace exanb
       {
         if(m_info.size() == 0) return;
         if(m_data.size() == 0) return;
+        assert ( migration_test::check_value_consistency(onika::cuda::span{m_data.data(), m_data.size()}) && "before compression" );
         // compress for each particle
         UIntType cur_off = 0;
         size_t itData = 0;
@@ -420,7 +421,7 @@ namespace exanb
         // some tests
         check_info_consistency();
         check_info_value();
-        assert ( migration_test::check_value_consistency(onika::cuda::span{m_data.data(), m_data.size()}) );
+        assert ( migration_test::check_value_consistency(onika::cuda::span{m_data.data(), m_data.size()}) && "after compression" );
 /*
         [[maybe_unused]] auto [last_offset, last_size, last_id] = m_info.back();
         assert ( itData == last_offset + last_size );

--- a/src/extra_storage/include/exanb/extra_storage/dynamic_data_storage.hpp
+++ b/src/extra_storage/include/exanb/extra_storage/dynamic_data_storage.hpp
@@ -194,6 +194,7 @@ namespace exanb
      */
     inline void encode_cell_to_buffer ( void* buffer )
     {
+      assert ( migration_test::check_value_consistency(onika::cuda::span{m_data.data(), m_data.size()}) );
       // get size in bytes
       const size_t info_size = m_info.size() * sizeof(InfoType);
       const size_t data_size = m_data.size() * sizeof(ItemType);
@@ -260,6 +261,8 @@ namespace exanb
       // first informaions, then items
       std::copy ( buff_info_ptr, buff_info_ptr + info_size, info_ptr );
       std::copy ( buff_data_ptr, buff_data_ptr + data_size, data_ptr );
+
+      assert ( migration_test::check_value_consistency(onika::cuda::span{m_data.data(), m_data.size()}) );
     }
 
     inline void append_data_stream_range (const uint8_t* buffer, size_t start, size_t end)
@@ -320,6 +323,7 @@ namespace exanb
       // now resize data and copy new data in this memory place
       m_data.resize(old_data_size + new_items_to_append);
       std::copy ( buff_data + first_item , buff_data + last_item , m_data.data() + old_data_size);  
+      assert ( migration_test::check_value_consistency(onika::cuda::span{m_data.data(), m_data.size()}) );
     }
 
     /**
@@ -416,6 +420,7 @@ namespace exanb
         // some tests
         check_info_consistency();
         check_info_value();
+        assert ( migration_test::check_value_consistency(onika::cuda::span{m_data.data(), m_data.size()}) );
 /*
         [[maybe_unused]] auto [last_offset, last_size, last_id] = m_info.back();
         assert ( itData == last_offset + last_size );

--- a/src/extra_storage/include/exanb/extra_storage/migration_test.hpp
+++ b/src/extra_storage/include/exanb/extra_storage/migration_test.hpp
@@ -75,7 +75,7 @@ namespace exanb
 
 
     template<typename ItemType>
-    inline bool well_defined(const ItemType& item) { return true }
+    inline bool well_defined(const ItemType& item) { return true; }
 
     // This function checks if the values are well defined
     // "well_defined" couuld be implemented by the developper for a given ItemType.

--- a/src/extra_storage/include/exanb/extra_storage/migration_test.hpp
+++ b/src/extra_storage/include/exanb/extra_storage/migration_test.hpp
@@ -85,7 +85,7 @@ namespace exanb
     {
       for (size_t i = 0 ; i < data_ptr.size() ; i++)
       {
-        if (well_defined(data_ptr[i]))
+        if (!well_defined(data_ptr[i]))
         {
           return false;
         }

--- a/src/extra_storage/include/exanb/extra_storage/migration_test.hpp
+++ b/src/extra_storage/include/exanb/extra_storage/migration_test.hpp
@@ -72,5 +72,25 @@ namespace exanb
 			}
 			return true;
 		}
+
+
+    template<typename ItemType>
+    inline bool well_defined(const ItemType& item) { return true }
+
+    // This function checks if the values are well defined
+    // "well_defined" couuld be implemented by the developper for a given ItemType.
+    // By default, well_defined return always true.
+    template<typename ItemType>
+    inline bool check_value_consistency(onika::cuda::span<ItemType> data_ptr)
+    {
+      for (size_t i = 0 ; i < data_ptr.size() ; i++)
+      {
+        if (well_defined(data_ptr[i]))
+        {
+          return false;
+        }
+      }
+      return true;
+    }
 	}
 }


### PR DESCRIPTION
Added a test function that checks whether the values stored in the dynamic extra storage are out of bounds. This check must be defined by the application using the extra storage (in the case of `exaDEM`, `well_defined` is defined for interactions). By default, this test is non-blocking.

Available only in debug mode.